### PR TITLE
todo app: create schema via `bcc migrate` instead of hand-written SQL

### DIFF
--- a/bcc.cpp
+++ b/bcc.cpp
@@ -350,6 +350,12 @@ static int runTests( int argc, char *argv[] )
 	return ( failed > 0 ) ? 1 : 0;
 }
 
+// Forward declarations (defined later) so migrate can resolve stdlib imports
+// the same way `bcc build` does.
+static set<string> parseImports( const string &path );
+static vector<string> resolveStdlibFiles( const string &exeDir,
+	const set<string> &imports );
+
 // bcc migrate subcommand
 //
 // Compares current table struct definitions against stored schema snapshot
@@ -399,7 +405,23 @@ static int runMigrate( int argc, char *argv[] )
 	string storedSchemaPath = ".blang/schema.json";
 	string currentSchemaPath = ".blang/schema.current.json";
 
-	vector<string> qccCmd = { qcc, "--emit-schema", currentSchemaPath };
+	// Resolve stdlib imports so projects that `import net;` (etc.) parse — the
+	// table struct lives in a source file that references stdlib symbols, so the
+	// stdlib modules must be combined into the same parse, exactly as bcc build
+	// does. User sources go last (combine treats the last file as user scope).
+	set<string> imports;
+	for ( const auto &f : sourceFiles )
+		for ( const auto &imp : parseImports( f ) )
+			imports.insert( imp );
+	vector<string> stdlibFiles = resolveStdlibFiles( exeDir, imports );
+
+	vector<string> qccCmd = { qcc };
+	if ( !stdlibFiles.empty() )
+		qccCmd.push_back( "--combine" );
+	qccCmd.push_back( "--emit-schema" );
+	qccCmd.push_back( currentSchemaPath );
+	for ( const auto &sf : stdlibFiles )
+		qccCmd.push_back( sf );
 	for ( const auto &f : sourceFiles )
 		qccCmd.push_back( f );
 	if ( runCommand( qccCmd, false, true ) != 0 )

--- a/examples/todo_app/.gitignore
+++ b/examples/todo_app/.gitignore
@@ -1,4 +1,5 @@
 /todos.db
 /todo_app
+/.blang/
 *.ll
 *.o

--- a/examples/todo_app/README.md
+++ b/examples/todo_app/README.md
@@ -16,13 +16,17 @@ end-to-end and doubles as an integration test for these features:
 
 ```sh
 cd examples/todo_app
-bcc build
+bcc build              # compile the app
+bcc migrate --apply    # create the SQLite schema from the Todo table struct
 ./todo_app
 # open http://localhost:8080
 ```
 
 `bcc build` reads `blang.toml`, combines `main.b` with the `net` stdlib module,
-and links the SQLite-backed database runtime. Todos persist in `todos.db`.
+and links the SQLite-backed database runtime. `bcc migrate --apply` derives the
+schema directly from the `table struct Todo` and creates the table in `todos.db`
+— there is **no hand-written `CREATE TABLE`** in the app. Use
+`bcc migrate --preview` to see the SQL it would run. Todos persist in `todos.db`.
 
 ## REST API
 

--- a/examples/todo_app/main.b
+++ b/examples/todo_app/main.b
@@ -5,22 +5,22 @@
 // back into an `Array<Todo>`, all served over HTTP and serialized with @json.
 //
 // Build & run:
-//   cd examples/todo_app && bcc build && ./todo_app
+//   cd examples/todo_app && bcc build && bcc migrate --apply && ./todo_app
 // then open http://localhost:8080
+//
+// `bcc migrate --apply` creates the SQLite schema directly from the `Todo`
+// table struct below — no hand-written CREATE TABLE needed.
 
 import net;
 
 // A single struct used both as the SQLite-backed table (`table`) and as the
-// JSON wire format (`@json`).
+// JSON wire format (`@json`). `bcc migrate` derives the schema from this.
 @json
 table struct Todo {
 	int id;
 	string title;
 	bool done;
 }
-
-// Execute raw SQL (CREATE TABLE) against the default connection.
-extern fn __blang_db_exec_raw_default(cstring sql) -> int;
 
 // The single-page frontend, served as static text/html. Uses single-quoted
 // attributes/strings so the BLang string literal needs no escaping, and avoids
@@ -182,11 +182,9 @@ fn handle(net.HttpRequest req) -> net.HttpResponse {
 }
 
 fn main() -> int {
-	// The Todo table is created on first run; the default connection is opened
-	// at startup from blang.toml's [database] section.
-	__blang_db_exec_raw_default(
-		"CREATE TABLE IF NOT EXISTS todo (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, done INTEGER)" );
-
+	// The default connection is opened at startup from blang.toml's [database]
+	// section. The schema is created beforehand by `bcc migrate --apply`, so the
+	// app contains no table-creation SQL.
 	net.HttpServer server = net.http_server("0.0.0.0", 8080);
 	server.on_request(handle);
 	println("Todo app listening on http://localhost:8080");

--- a/examples/todo_app/test_todo_app.sh
+++ b/examples/todo_app/test_todo_app.sh
@@ -31,17 +31,22 @@ if [ ! -x "$BCC" ]; then
 fi
 
 cd "$APP_DIR" || exit 1
-rm -f todos.db
+rm -rf todos.db .blang
 
 echo "=== building todo_app ==="
 if ! "$BCC" build > /tmp/todo_build.log 2>&1; then
 	echo -e "${RED}build failed${NC}"; tail -5 /tmp/todo_build.log; exit 1
 fi
 
+echo "=== migrating schema (creates the todo table from the table struct) ==="
+if ! "$BCC" migrate --apply > /tmp/todo_migrate.log 2>&1; then
+	echo -e "${RED}migrate failed${NC}"; tail -5 /tmp/todo_migrate.log; exit 1
+fi
+
 echo "=== starting server ==="
 ./todo_app > /tmp/todo_run.log 2>&1 &
 SRV=$!
-trap 'kill $SRV 2>/dev/null; rm -f todos.db' EXIT
+trap 'kill $SRV 2>/dev/null; rm -rf todos.db .blang' EXIT
 
 # Wait for the server to accept connections (up to ~5s).
 for _ in $(seq 1 50); do

--- a/test_migrate.sh
+++ b/test_migrate.sh
@@ -99,6 +99,28 @@ check "destructive apply refused without flag" 1 $?
 $BCC migrate --apply --allow-destructive app.b > /dev/null 2>&1
 check "destructive apply allowed with flag" 0 $?
 
+# 4. Schema extraction for a project that imports a stdlib module. The table
+#    struct lives in a file that references stdlib symbols (net.*), so migrate
+#    must combine the imported stdlib to parse it (regression for that fix).
+mkdir -p imp && cd imp
+cat > app.b <<'EOF'
+import net;
+
+table struct Note {
+	int id;
+	string body;
+}
+
+fn ping(net.HttpRequest req) -> net.HttpResponse {
+	return net.http_ok("pong");
+}
+
+fn main() -> int { return 0; }
+EOF
+out="$($BCC migrate --preview app.b 2>/dev/null)"
+check_contains "migrate parses stdlib-importing project" "Create table Note" "$out"
+cd ..
+
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

The todo example described its table twice — once as `table struct Todo` and again as a raw `__blang_db_exec_raw_default("CREATE TABLE ...")` call. This switches it to the migration workflow: the schema is now derived from the struct by `bcc migrate --apply`, and the app contains **no table-creation SQL**.

## Enabler: fix `bcc migrate` to resolve stdlib imports

`bcc migrate` extracted the schema by running `qcc --emit-schema <sources>` with no import resolution, so any project that `import`s a stdlib module (the todo app imports `net`) failed to parse — the table struct lives in a file that references `net.*` symbols. `runMigrate` now resolves imports with the existing `parseImports` / `resolveStdlibFiles` helpers and invokes `qcc --combine --emit-schema <stdlib...> <sources...>`, exactly as `bcc build` does (user sources go last so combine treats them as the user scope).

## Changes

- **`bcc.cpp`** — `runMigrate` resolves stdlib imports + combines them before schema extraction (with forward declarations for the reused helpers).
- **`examples/todo_app/main.b`** — removed the `extern fn __blang_db_exec_raw_default` declaration and the `CREATE TABLE` call; the `table struct Todo` is the single source of truth.
- **`examples/todo_app/README.md` / `test_todo_app.sh` / `.gitignore`** — document and test the `build → migrate --apply → run` workflow; ignore the `.blang/` snapshot dir.
- **`test_migrate.sh`** — added a regression case migrating a project that imports a stdlib module (would fail without the fix).

## New workflow

```sh
cd examples/todo_app
bcc build
bcc migrate --apply    # creates the todo table from the table struct
./todo_app
```

## Verification

- `bcc migrate --preview` on the todo app now prints `Create table Todo` (previously failed to parse).
- Full workflow: build → `migrate --apply` ("applied: Create table Todo") → CRUD over HTTP works with zero SQL in the app; persistence holds across restart.
- Suites green: **167 unit, 77 codegen E2E, 9 migrate (incl. new import case), 8 todo-app integration**.

## Tradeoff

The app no longer self-bootstraps its database, so `bcc migrate --apply` must run before first launch (reflected in the README and integration test). A future opt-in `auto_migrate` at startup could restore self-bootstrapping if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wh5TjYg4CbEY3FaARMpVDo)_