### PR TITLE
[blang-ast][U1] Source locations end to end

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-source-locations"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,8 +301,17 @@ All AST nodes inherit from `RefCount` (defined in `RefCount.h`). Ownership is ma
 
 ### Error handling
 
-- `CompileError` exception class carries the error message, source file, and line number.
-- `COMPILE_ERROR(lexer, message)` macro throws a `CompileError` with `__FILE__` and `__LINE__`.
+- Every AST node carries a `SourceLocation {file, line, col}` (`SourceLocation.h`),
+  stamped at parse time by each `Parse` factory. The lexer freezes each token's
+  1-based line/column into its symbol-replay list (`FileLexer.*`,
+  `LexerReader.cpp` counts in `popChar`), so `Lexer::getTokenLocation()` is
+  accurate even after parser backtracking. `--dump-locations` renders these.
+- `CompileError` exception class carries the offending token's `SourceLocation`
+  (snapshotted at throw time via `COMPILE_ERROR`) plus the compiler-internal
+  `__FILE__`/`__LINE__` (retained for a future `--debug-compiler` mode). Error
+  reporting no longer reads the live lexer.
+- `COMPILE_ERROR(lexer, message)` macro throws a `CompileError` with the token
+  location and `__FILE__`/`__LINE__`.
 - The top-level `Module::Parse` has a try/catch that prints the error and returns `nullptr`.
 
 ## Code Conventions
@@ -487,7 +496,7 @@ This is an active work-in-progress. The recursive-descent parser can parse BLang
 
 **Lexer keywords**: `fn`, `bool`, `struct`, `impl`, `self`, `protocol`, `match`, `import`, `pub`, `break`, `continue`, `enum`, `in`, `own`, `shared`, `sync`, `spawn`, `chan`, `async`, `await`, `on`, `requires`, `ensures`, `test`, `assert`, `table`, `query`, `insert`, `update`, `delete`, `cstring`, `carray`. Additional tokens: `->` (arrow), `..` (range), `_` (wildcard), `?` (try operator), `|>` (pipeline), `@` (annotation), `true`/`false` (boolean constants), float constants.
 
-**CLI features**: `qcc` supports `--parse-only`, `-S`/`--emit-ir`, `-c`/`--emit-obj`, `-o`/`--output`, `--emit-bmod <file>`, `--combine` (compile multiple `.b` files into a single `.ll` with shared scope), `--help` flags and multiple input files (`.b` and `.bmod`). `bcc build` reads `blang.toml`, resolves dependencies, and builds projects (lib→.a+.bmod, bin→executable) with content-addressable caching. `bcc clean` removes the build cache. `bcc test` subcommand discovers and runs test files. `bcc migrate` subcommand supports `--preview`, `--apply`, and `--generate` modes for schema migrations.
+**CLI features**: `qcc` supports `--parse-only`, `-S`/`--emit-ir`, `-c`/`--emit-obj`, `-o`/`--output`, `--emit-bmod <file>`, `--combine` (compile multiple `.b` files into a single `.ll` with shared scope), `--dump-locations` (print one `<file>:<line>:<col> <NodeKind>` line per AST node in deterministic pre-order, then exit; parse-only, no LLVM dependency; locked by the golden files under `test_files/golden/`), `--help` flags and multiple input files (`.b` and `.bmod`). `bcc build` reads `blang.toml`, resolves dependencies, and builds projects (lib→.a+.bmod, bin→executable) with content-addressable caching. `bcc clean` removes the build cache. `bcc test` subcommand discovers and runs test files. `bcc migrate` subcommand supports `--preview`, `--apply`, and `--generate` modes for schema migrations.
 
 **Runtime libraries**: `blang_string` (safe immutable string type — `BlangString` with refcounting, heap allocation, and bounds-checked access), `blang_array` (safe generic array type — `BlangArray` with refcounting, bounds-checked access, and dynamic growth), `blang_json` (C library for JSON encode/decode), `blang_net` (TCP sockets + poll-based Selector event loop — listen/accept/connect/read/write/close, event-driven I/O with fd-based handle table), `blang_fs` (file I/O + directory operations — open/close/read/write/seek/flush, stat/remove/mkdir/list_dir), `blang_db` (database abstraction with optional SQLite backend).
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(QCC_SOURCES
 	QQueryExpression.cpp
 	QLambdaExpression.cpp
 	BmodEmitter.cpp
+	LocationDumper.cpp
 	FormatString.cpp)
 
 # Add LLVM code generation when available

--- a/CompilerHelpers.h
+++ b/CompilerHelpers.h
@@ -4,34 +4,39 @@
 #include <iostream>
 #include <string>
 
+#include "SourceLocation.h"
+
 class CompileError
 {
 public:
-	CompileError( Lexer &l, std::string message, const char *filename, int lineno ) : 
-		mLexer( l ), mMessage( message ), 
+	CompileError( const SourceLocation &loc, std::string message,
+		const char *filename, int lineno ) :
+		mLocation( loc ), mMessage( message ),
 		mFilename( filename ), mLineno( lineno )
 	{}
-	
+
 	std::string getMessage() const;
-	
+
+	// Source location of the offending token, snapshotted at throw time.
+	// Reporting reads this instead of interrogating the live lexer.
+	const SourceLocation &getLocation() const { return mLocation; }
+
+	// Compiler-internal C++ __FILE__:__LINE__ of the throw site — retained
+	// for a future --debug-compiler mode (U2); never part of normal output.
+	const char *getInternalFile() const { return mFilename; }
+	int getInternalLine() const { return mLineno; }
+
 private:
-	Lexer	&mLexer;
+	SourceLocation mLocation;
 	std::string mMessage;
 	const char *mFilename;
 	int mLineno;
 };
 
+// Throw a located compile error. `l` must be a Lexer (its full definition
+// is available at every call site); the token location is snapshotted now.
 #define COMPILE_ERROR( l, message ) \
-	throw CompileError( l, message, __FILE__, __LINE__ )
-	
-#if 0
-#define COMPILE_ERROR( l, message ) \
-do { \
-	cerr << "Compiler Error in " << __FILE__ << ":" << __LINE__ << endl; \
-	cerr << message << " at line: " << l.getLineNumber() << endl; \
-	exit( -1 ); \
-} while( false )
-#endif
+	throw CompileError( (l).getTokenLocation(), message, __FILE__, __LINE__ )
 
 template <typename T>
 std::ostream &operator<<(std::ostream &out, const SmartPtr<T> &ptr)

--- a/Expression.h
+++ b/Expression.h
@@ -41,6 +41,7 @@ namespace QLang
 		SmartPtr<Expression> mLoopExpression;
 		SmartPtr<Statement> mLoopStatement;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class ForStatement : public Statement
@@ -58,6 +59,7 @@ namespace QLang
 		SmartPtr<Expression> mIterationExpression;
 		SmartPtr<Statement> mStatement;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class ForInStatement : public Statement
@@ -76,6 +78,7 @@ namespace QLang
 		SmartPtr<Statement> mBody;
 		bool mIsInfinite = false;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class IfStatement : public Statement
@@ -92,6 +95,7 @@ namespace QLang
 		SmartPtr<Statement> mStatement;
 		SmartPtr<Statement> mElseStatement;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class ReturnStatement : public Statement
@@ -106,6 +110,7 @@ namespace QLang
 	private:
 		SmartPtr<Expression> mExpression;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 	
 	class ConstExpression : public Expression
@@ -128,6 +133,7 @@ namespace QLang
 	private:
 		int64_t mValue;
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class SQLGen;
 	};
 
@@ -139,6 +145,7 @@ namespace QLang
 	private:
 		double mValue;
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class SQLGen;
 	};
 
@@ -150,6 +157,7 @@ namespace QLang
 	private:
 		std::string mValue;
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class SQLGen;
 	};
 	
@@ -167,6 +175,7 @@ namespace QLang
 	private:
 		std::string mValue;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class VariableDeclaration : public Statement
@@ -182,6 +191,7 @@ namespace QLang
 		
 		std::vector<DeclData> mVariables;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 	
 	class VariableExpression : public Expression
@@ -199,6 +209,7 @@ namespace QLang
 	private:
 		SmartPtr<VariableDefinition> mVariable;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class CallExpression : public Expression
@@ -221,6 +232,7 @@ namespace QLang
 		std::vector<SmartPtr<Expression> > mParams;
 		std::string mMangledName;  // namespace-mangled name, empty if not mangled
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 	
 	class Block : public Statement
@@ -232,6 +244,7 @@ namespace QLang
 		SmartPtr<Scope> mScope;
 		std::vector<SmartPtr<Statement> > mStatementList;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class AssignmentExpression : public Expression
@@ -245,6 +258,7 @@ namespace QLang
 		SmartPtr<VariableDefinition> mVariable;
 		SmartPtr<Expression> mValue;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class FieldAssignmentExpression : public Expression
@@ -260,6 +274,7 @@ namespace QLang
 		std::string mFieldName;
 		SmartPtr<Expression> mValue;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class IndexAssignmentExpression : public Expression
@@ -275,6 +290,7 @@ namespace QLang
 		SmartPtr<Expression> mIndex;
 		SmartPtr<Expression> mValue;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class OperationsExpression : public Expression
@@ -288,6 +304,7 @@ namespace QLang
 		SmartPtr<Expression> mOp1;
 		SmartPtr<Expression> mOp2;
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class SQLGen;
 	};
 
@@ -301,6 +318,7 @@ namespace QLang
 		std::string mOperation;
 		SmartPtr<Expression> mOperand;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class BreakStatement : public Statement
@@ -314,6 +332,7 @@ namespace QLang
 
 	private:
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class ContinueStatement : public Statement
@@ -327,6 +346,7 @@ namespace QLang
 
 	private:
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class SpawnStatement : public Expression
@@ -340,6 +360,7 @@ namespace QLang
 	private:
 		SmartPtr<Block> mBody;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class WaitStatement : public Statement
@@ -353,6 +374,7 @@ namespace QLang
 	private:
 		SmartPtr<Expression> mExpr;   // the Task expression to wait on
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class WaitAllStatement : public Statement
@@ -365,6 +387,7 @@ namespace QLang
 
 	private:
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class AssertStatement : public Statement
@@ -379,6 +402,7 @@ namespace QLang
 		SmartPtr<Expression> mExpression;
 		std::string mMessage;  // optional assertion message
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class EventHandler : public Statement
@@ -393,6 +417,7 @@ namespace QLang
 		SmartPtr<Expression> mEventExpression;  // e.g., timer.every(1000)
 		SmartPtr<Block> mBody;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class FieldAccessExpression : public Expression
@@ -410,6 +435,7 @@ namespace QLang
 		SmartPtr<Expression> mObject;
 		std::string mFieldName;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class StructLiteralExpression : public Expression
@@ -433,6 +459,7 @@ namespace QLang
 		std::vector<std::string> mFieldNames;
 		std::vector<SmartPtr<Expression>> mFieldValues;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class ArrayLiteralExpression : public Expression
@@ -447,6 +474,7 @@ namespace QLang
 	private:
 		std::vector<SmartPtr<Expression>> mElements;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class IndexExpression : public Expression
@@ -462,6 +490,7 @@ namespace QLang
 		SmartPtr<Expression> mObject;
 		SmartPtr<Expression> mIndex;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class MethodCallExpression : public Expression
@@ -477,6 +506,7 @@ namespace QLang
 		std::string mMethodName;
 		std::vector<SmartPtr<Expression>> mArgs;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class RangeExpression : public Expression
@@ -489,6 +519,7 @@ namespace QLang
 		SmartPtr<Expression> mStart;
 		SmartPtr<Expression> mEnd;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class StringInterpolation : public Expression
@@ -503,6 +534,7 @@ namespace QLang
 	private:
 		std::vector<SmartPtr<Expression>> mParts;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class ConstructExpression : public Expression
@@ -517,6 +549,7 @@ namespace QLang
 		std::vector<SmartPtr<Type>> mTypeArgs;
 		std::vector<SmartPtr<Expression>> mArgs;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class EnumConstructExpression : public Expression
@@ -532,6 +565,7 @@ namespace QLang
 		int mVariantIndex;
 		std::vector<SmartPtr<Expression>> mArgs;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	struct MatchArm
@@ -555,6 +589,7 @@ namespace QLang
 		SmartPtr<Expression> mSubject;
 		std::vector<MatchArm> mArms;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class TryExpression : public Expression
@@ -565,6 +600,7 @@ namespace QLang
 	private:
 		SmartPtr<Expression> mOperand;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class AwaitExpression : public Expression
@@ -575,6 +611,7 @@ namespace QLang
 	private:
 		SmartPtr<Expression> mOperand;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class FunctionRefExpression : public Expression
@@ -585,6 +622,7 @@ namespace QLang
 	private:
 		SmartPtr<FunctionDefinition> mFunction;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class LambdaExpression : public Expression
@@ -600,6 +638,7 @@ namespace QLang
 		std::vector<SmartPtr<VariableDefinition>> mParameters;
 		SmartPtr<Block> mBody;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class IndirectCallExpression : public Expression
@@ -613,6 +652,7 @@ namespace QLang
 		SmartPtr<VariableDefinition> mFnVariable;
 		std::vector<SmartPtr<Expression>> mParams;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	// Phase 3: Pipeline expression — a |> b desugars to b(a)
@@ -626,6 +666,7 @@ namespace QLang
 		SmartPtr<Expression> mInput;
 		SmartPtr<Expression> mTransform;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	// Phase 3: Query field reference — .field_name in query context
@@ -639,6 +680,7 @@ namespace QLang
 	private:
 		std::string mFieldName;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	// Phase 3: Query pipeline step types
@@ -666,6 +708,7 @@ namespace QLang
 		std::string mTableName;
 		std::vector<QueryPipelineStep> mSteps;
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class SQLGen;
 	};
 
@@ -688,6 +731,7 @@ namespace QLang
 		std::vector<std::string> mFieldNames;
 		std::vector<SmartPtr<Expression>> mFieldValues;
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class SQLGen;
 	};
 
@@ -705,6 +749,7 @@ namespace QLang
 		std::string mTableName;
 		std::vector<QueryPipelineStep> mSteps;
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class SQLGen;
 	};
 
@@ -722,6 +767,7 @@ namespace QLang
 		std::string mTableName;
 		std::vector<QueryPipelineStep> mSteps;
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class SQLGen;
 	};
 };

--- a/FileLexer.cpp
+++ b/FileLexer.cpp
@@ -99,9 +99,6 @@ void Lexer::readStringConst()
 	
 	while ( !mReader->isEOF() )
 	{
-		if ( mReader->peekChar() == '\n' )
-			printf( "Multi-line string constant on line %d\n", lineno );
-		
 		if ( mReader->peekChar() == '\\' )
 		{
 			switch ( (*mReader)[ 1 ] )
@@ -171,10 +168,7 @@ void Lexer::readCharacterConst()
 	
 	while ( !mReader->isEOF() )
 	{
-		if ( mReader->peekChar() == '\n' )
-			printf( "Multi-line char constant on line %d\n", lineno );
-
-		// could improve the proper grammmer for the constant value.		
+		// could improve the proper grammmer for the constant value.
 		if ( mReader->peekChar() != '\'' )
 		{
 			mMatchString.append( 1, mReader->popChar() );
@@ -310,7 +304,7 @@ int Lexer::getSymbolInternal()
 	if ( mCurrentPos == mSymbolList.size() )
 	{
 		sym = getSymbolFromFile();
-		mSymbolList.push_back( SymbolInfo( sym, mMatchString ) );
+		mSymbolList.push_back( SymbolInfo( sym, mMatchString, mScanLine, mScanCol ) );
 	}
 	else
 	{
@@ -318,23 +312,50 @@ int Lexer::getSymbolInternal()
 		mMatchString = mSymbolList[ mCurrentPos ].symbolText;
 	}
 
-	if ( sym <= Lexer::QUESTION_MARK || (sym >= 256 && sym < Lexer::NUM_SYMBOLS) )
-		std::cout << "Symbol " << sym << " (" << mMatchString << ")" << std::endl;
-	else
-		std::cout << "Symbol " << (char)sym << std::endl;
-	
+	if ( mTraceEnabled )
+	{
+		if ( sym <= Lexer::QUESTION_MARK || (sym >= 256 && sym < Lexer::NUM_SYMBOLS) )
+			std::cout << "Symbol " << sym << " (" << mMatchString << ")" << std::endl;
+		else
+			std::cout << "Symbol " << (char)sym << std::endl;
+	}
+
 	return sym;
+}
+
+SourceLocation Lexer::getTokenLocation()
+{
+	// Ensure the token at the current parse position has been scanned into
+	// the symbol list (peekSymbol reads at mCurrentPos without advancing).
+	peekSymbol();
+	if ( mCurrentPos >= 0 && (std::size_t)mCurrentPos < mSymbolList.size() )
+	{
+		const SymbolInfo &info = mSymbolList[ mCurrentPos ];
+		return SourceLocation( mReader->getFileName(), info.line, info.col );
+	}
+	// Fallback: position at end of input (e.g. missing closing brace).
+	return SourceLocation( mReader->getFileName(), mReader->getLine(), mReader->getCol() );
 }
 
 int Lexer::getSymbolFromFile()
 {
 	mMatchString.clear();
 	mLastSym = -1;
-	
+
+	// Position used if we fall through to EOF without recognizing a token.
+	mScanLine = mReader->getLine();
+	mScanCol = mReader->getCol();
+
 	while ( !mReader->isEOF() )
 	{
 		//std::cout << "Lexer Symbol " << (int)mReader->peekChar() << std::endl;
-		
+
+		// Snapshot the position of this candidate token's first character.
+		// Whitespace/comment branches below consume and re-loop, so the
+		// snapshot that survives to a return is the real token start.
+		mScanLine = mReader->getLine();
+		mScanCol = mReader->getCol();
+
 		// check for keywords
 		switch ( mReader->peekChar() )
 		{

--- a/FileLexer.h
+++ b/FileLexer.h
@@ -6,21 +6,31 @@
 #include <string>
 #include <vector>
 
+#include "SourceLocation.h"
+
 class LexerReader
 {
 public:
 	LexerReader( const std::string &filename );
-	
+
 	char operator[]( int i );
-	
+
 	char popChar();
 	void popChar( int count );
 	char peekChar();
-	
+
 	bool isEOF();
-	
+
+	// Position of the next unconsumed character (1-based).
+	const std::string &getFileName() const { return mFileName; }
+	uint32_t getLine() const { return mLine; }
+	uint32_t getCol() const { return mCol; }
+
 private:
 	std::ifstream mFile;
+	std::string mFileName;
+	uint32_t mLine = 1;
+	uint32_t mCol = 1;
 };
 
 class Lexer
@@ -105,10 +115,21 @@ public:
 	};
 	
 	bool isEOF() { return mReader->isEOF(); }
-		
-	uint32_t getLineNumber() { return lineno; }
-	uint32_t getLinePosition() { return charPos; }
-	
+
+	// Line/column/location of the token at the current parse position — the
+	// token the parser is about to consume. Accurate after setCurrentPos
+	// backtracking because positions are frozen into the symbol list at
+	// scan time. getLineNumber()/getLinePosition() delegate here so error
+	// reporting is token-accurate rather than reflecting file read-ahead.
+	SourceLocation getTokenLocation();
+	const std::string &getFileName() const { return mReader->getFileName(); }
+	uint32_t getLineNumber() { return getTokenLocation().line; }
+	uint32_t getLinePosition() { return getTokenLocation().col; }
+
+	// Gate the per-token diagnostic echo (off = quiet). Default preserves
+	// the historical behavior; qcc disables it for --dump-locations.
+	void setTraceEnabled( bool enabled ) { mTraceEnabled = enabled; }
+
 protected:
 	bool match( const char *match_str );
 	bool matchKeyword( const char *match_str );
@@ -128,15 +149,24 @@ private:
 	int			mLastSym;
 	uint32_t	lineno;
 	uint32_t	charPos;
-	
-	struct SymbolInfo 
+	bool		mTraceEnabled = true;
+	// Position of the first character of the token most recently scanned
+	// from the file; frozen into SymbolInfo so replay/backtracking returns
+	// exact positions.
+	uint32_t	mScanLine = 1;
+	uint32_t	mScanCol = 1;
+
+	struct SymbolInfo
 	{
-		SymbolInfo( int s, std::string &str ) : symbol( s ), symbolText( str ) {}
-		
+		SymbolInfo( int s, std::string &str, uint32_t l, uint32_t c ) :
+			symbol( s ), symbolText( str ), line( l ), col( c ) {}
+
 		int symbol;
 		std::string symbolText;
+		uint32_t line;
+		uint32_t col;
 	};
-	
+
 	std::vector<SymbolInfo> mSymbolList;
 	int mCurrentPos;
 	

--- a/LexerReader.cpp
+++ b/LexerReader.cpp
@@ -1,6 +1,6 @@
 #include "FileLexer.h"
 
-LexerReader::LexerReader( const std::string &filename )
+LexerReader::LexerReader( const std::string &filename ) : mFileName( filename )
 {
 	mFile.open( filename.c_str() );
 }
@@ -15,16 +15,31 @@ char LexerReader::operator[]( int i )
 	mFile.seekg( orig_p );
 	return c;
 }
-	
+
 char LexerReader::popChar()
 {
-	return mFile.get();
+	char c = mFile.get();
+	// Track 1-based line/column of the next unconsumed character. Every
+	// character consumed advances the column by one (tabs included); a
+	// newline advances the line and resets the column. This is the single
+	// consumption funnel, so multi-line strings and block comments are
+	// counted correctly.
+	if ( c == '\n' )
+	{
+		mLine += 1;
+		mCol = 1;
+	}
+	else
+	{
+		mCol += 1;
+	}
+	return c;
 }
 
 void LexerReader::popChar( int count )
 {
 	for ( int i = 0; i < count; i++ )
-		mFile.get();
+		popChar();
 }
 
 char LexerReader::peekChar()
@@ -38,4 +53,3 @@ bool LexerReader::isEOF()
 	mFile.peek();
 	return mFile.eof();
 }
-

--- a/LocationDumper.cpp
+++ b/LocationDumper.cpp
@@ -1,0 +1,296 @@
+#include "LocationDumper.h"
+
+#include <cxxabi.h>
+#include <cstdlib>
+#include <string>
+#include <typeinfo>
+
+using namespace QLang;
+
+// Demangle a typeid name and strip a leading "QLang::" namespace qualifier
+// so the printed kind is the bare AST class name (e.g. FunctionDefinition,
+// ReturnStatement, ConstInteger). Stable on the Itanium C++ ABI (the
+// project's Linux/macOS toolchains).
+static std::string nodeKind( const std::type_info &ti )
+{
+	int status = 0;
+	char *demangled = abi::__cxa_demangle( ti.name(), nullptr, nullptr, &status );
+	std::string name = ( status == 0 && demangled != nullptr ) ? demangled : ti.name();
+	if ( demangled != nullptr )
+		free( demangled );
+
+	const std::string prefix = "QLang::";
+	if ( name.compare( 0, prefix.size(), prefix ) == 0 )
+		name = name.substr( prefix.size() );
+	return name;
+}
+
+void LocationDumper::dump( const Module *mod, std::ostream &out )
+{
+	LocationDumper dumper( out );
+	dumper.visitModule( mod );
+}
+
+void LocationDumper::emit( const SourceLocation &loc, const char *kind )
+{
+	mOut << loc.file << ":" << loc.line << ":" << loc.col << " " << kind << "\n";
+}
+
+void LocationDumper::visitModule( const Module *mod )
+{
+	// Deterministic pre-order across the module's top-level declarations.
+	// The parser stores each declaration kind in its own list, so a fixed
+	// category order (imports, structs, enums, protocols, functions, tests)
+	// gives a stable dump; within each list, order is source order.
+	for ( const auto &imp : mod->mImports )
+		visitImport( imp );
+	for ( const auto &s : mod->mStructList )
+		visitStruct( s );
+	for ( const auto &e : mod->mEnumList )
+		visitEnum( e );
+	for ( const auto &p : mod->mProtocolList )
+		visitProtocol( p );
+	for ( const auto &f : mod->mFunctionList )
+		visitFunction( f );
+	for ( const auto &t : mod->mTestBlocks )
+		visitTestBlock( t );
+}
+
+void LocationDumper::visitImport( const ImportStatement *imp )
+{
+	emit( imp->getLocation(), "ImportStatement" );
+}
+
+void LocationDumper::visitFunction( const FunctionDefinition *func )
+{
+	emit( func->getLocation(), nodeKind( typeid( *func ) ).c_str() );
+
+	for ( const auto &param : func->mParameters )
+		visitVariableDef( param );
+	for ( const auto &req : func->mRequiresClauses )
+		visitStatement( req );
+	for ( const auto &ens : func->mEnsuresClauses )
+		visitStatement( ens );
+	if ( func->mFuncBody != nullptr )
+		visitStatement( func->mFuncBody );
+}
+
+void LocationDumper::visitVariableDef( const VariableDefinition *var )
+{
+	emit( var->getLocation(), nodeKind( typeid( *var ) ).c_str() );
+}
+
+void LocationDumper::visitStruct( const StructDefinition *structDef )
+{
+	emit( structDef->getLocation(), nodeKind( typeid( *structDef ) ).c_str() );
+	for ( const auto &field : structDef->mFields )
+		visitVariableDef( field );
+	for ( const auto &method : structDef->mMethods )
+		visitFunction( method );
+}
+
+void LocationDumper::visitEnum( const EnumDefinition *enumDef )
+{
+	emit( enumDef->getLocation(), nodeKind( typeid( *enumDef ) ).c_str() );
+}
+
+void LocationDumper::visitProtocol( const ProtocolDefinition *protoDef )
+{
+	emit( protoDef->getLocation(), nodeKind( typeid( *protoDef ) ).c_str() );
+	for ( const auto &method : protoDef->mRequiredMethods )
+		visitFunction( method );
+}
+
+void LocationDumper::visitTestBlock( const TestBlock *test )
+{
+	emit( test->getLocation(), "TestBlock" );
+	if ( test->mBody != nullptr )
+		visitStatement( test->mBody );
+}
+
+// Dispatch a Statement (or Expression — Expression derives from Statement)
+// to the correct child traversal. Every node is printed with its dynamic
+// class name; a node kind not explicitly handled still prints one line and
+// simply stops recursing (spec R6). Order of dynamic_casts: most-derived
+// expression kinds, then statements.
+void LocationDumper::visitStatement( const Statement *stmt )
+{
+	if ( stmt == nullptr )
+		return;
+
+	emit( stmt->getLocation(), nodeKind( typeid( *stmt ) ).c_str() );
+
+	// --- Expressions ---
+	if ( const auto *e = dynamic_cast<const OperationsExpression *>( stmt ) )
+	{
+		visitStatement( e->mOp1 );
+		visitStatement( e->mOp2 );
+	}
+	else if ( const auto *e = dynamic_cast<const UnaryExpression *>( stmt ) )
+	{
+		visitStatement( e->mOperand );
+	}
+	else if ( const auto *e = dynamic_cast<const AssignmentExpression *>( stmt ) )
+	{
+		visitStatement( e->mValue );
+	}
+	else if ( const auto *e = dynamic_cast<const FieldAssignmentExpression *>( stmt ) )
+	{
+		visitStatement( e->mObject );
+		visitStatement( e->mValue );
+	}
+	else if ( const auto *e = dynamic_cast<const IndexAssignmentExpression *>( stmt ) )
+	{
+		visitStatement( e->mObject );
+		visitStatement( e->mIndex );
+		visitStatement( e->mValue );
+	}
+	else if ( const auto *e = dynamic_cast<const CallExpression *>( stmt ) )
+	{
+		for ( const auto &p : e->mParams )
+			visitStatement( p );
+	}
+	else if ( const auto *e = dynamic_cast<const MethodCallExpression *>( stmt ) )
+	{
+		visitStatement( e->mObject );
+		for ( const auto &a : e->mArgs )
+			visitStatement( a );
+	}
+	else if ( const auto *e = dynamic_cast<const FieldAccessExpression *>( stmt ) )
+	{
+		visitStatement( e->mObject );
+	}
+	else if ( const auto *e = dynamic_cast<const IndexExpression *>( stmt ) )
+	{
+		visitStatement( e->mObject );
+		visitStatement( e->mIndex );
+	}
+	else if ( const auto *e = dynamic_cast<const ArrayLiteralExpression *>( stmt ) )
+	{
+		for ( const auto &el : e->mElements )
+			visitStatement( el );
+	}
+	else if ( const auto *e = dynamic_cast<const RangeExpression *>( stmt ) )
+	{
+		visitStatement( e->mStart );
+		visitStatement( e->mEnd );
+	}
+	else if ( const auto *e = dynamic_cast<const StringInterpolation *>( stmt ) )
+	{
+		for ( const auto &part : e->mParts )
+			visitStatement( part );
+	}
+	else if ( const auto *e = dynamic_cast<const StructLiteralExpression *>( stmt ) )
+	{
+		for ( const auto &v : e->mFieldValues )
+			visitStatement( v );
+	}
+	else if ( const auto *e = dynamic_cast<const ConstructExpression *>( stmt ) )
+	{
+		for ( const auto &a : e->mArgs )
+			visitStatement( a );
+	}
+	else if ( const auto *e = dynamic_cast<const EnumConstructExpression *>( stmt ) )
+	{
+		for ( const auto &a : e->mArgs )
+			visitStatement( a );
+	}
+	else if ( const auto *e = dynamic_cast<const TryExpression *>( stmt ) )
+	{
+		visitStatement( e->mOperand );
+	}
+	else if ( const auto *e = dynamic_cast<const AwaitExpression *>( stmt ) )
+	{
+		visitStatement( e->mOperand );
+	}
+	else if ( const auto *e = dynamic_cast<const IndirectCallExpression *>( stmt ) )
+	{
+		for ( const auto &p : e->mParams )
+			visitStatement( p );
+	}
+	else if ( const auto *e = dynamic_cast<const PipelineExpression *>( stmt ) )
+	{
+		visitStatement( e->mInput );
+		visitStatement( e->mTransform );
+	}
+	else if ( const auto *e = dynamic_cast<const LambdaExpression *>( stmt ) )
+	{
+		for ( const auto &param : e->mParameters )
+			visitVariableDef( param );
+		if ( e->mBody != nullptr )
+			visitStatement( e->mBody );
+	}
+	else if ( const auto *e = dynamic_cast<const SpawnStatement *>( stmt ) )
+	{
+		if ( e->mBody != nullptr )
+			visitStatement( e->mBody );
+	}
+	else if ( const auto *e = dynamic_cast<const MatchExpression *>( stmt ) )
+	{
+		visitStatement( e->mSubject );
+		for ( const auto &arm : e->mArms )
+		{
+			if ( arm.mBody != nullptr )
+				visitStatement( arm.mBody );
+		}
+	}
+	// --- Statements ---
+	else if ( const auto *s = dynamic_cast<const Block *>( stmt ) )
+	{
+		for ( const auto &child : s->mStatementList )
+			visitStatement( child );
+	}
+	else if ( const auto *s = dynamic_cast<const ReturnStatement *>( stmt ) )
+	{
+		if ( s->mExpression != nullptr )
+			visitStatement( s->mExpression );
+	}
+	else if ( const auto *s = dynamic_cast<const IfStatement *>( stmt ) )
+	{
+		visitStatement( s->mIfExpression );
+		visitStatement( s->mStatement );
+		if ( s->mElseStatement != nullptr )
+			visitStatement( s->mElseStatement );
+	}
+	else if ( const auto *s = dynamic_cast<const WhileStatement *>( stmt ) )
+	{
+		visitStatement( s->mLoopExpression );
+		visitStatement( s->mLoopStatement );
+	}
+	else if ( const auto *s = dynamic_cast<const ForInStatement *>( stmt ) )
+	{
+		if ( s->mIterableExpression != nullptr )
+			visitStatement( s->mIterableExpression );
+		if ( s->mBody != nullptr )
+			visitStatement( s->mBody );
+	}
+	else if ( const auto *s = dynamic_cast<const VariableDeclaration *>( stmt ) )
+	{
+		for ( const auto &decl : s->mVariables )
+		{
+			if ( decl.mVaribale != nullptr )
+				visitVariableDef( decl.mVaribale );
+			if ( decl.mInitialValue != nullptr )
+				visitStatement( decl.mInitialValue );
+		}
+	}
+	else if ( const auto *s = dynamic_cast<const AssertStatement *>( stmt ) )
+	{
+		if ( s->mExpression != nullptr )
+			visitStatement( s->mExpression );
+	}
+	else if ( const auto *s = dynamic_cast<const WaitStatement *>( stmt ) )
+	{
+		if ( s->mExpr != nullptr )
+			visitStatement( s->mExpr );
+	}
+	else if ( const auto *s = dynamic_cast<const EventHandler *>( stmt ) )
+	{
+		if ( s->mEventExpression != nullptr )
+			visitStatement( s->mEventExpression );
+		if ( s->mBody != nullptr )
+			visitStatement( s->mBody );
+	}
+	// Leaf nodes (ConstInteger, VariableExpression, BreakStatement, etc.)
+	// print their line above and need no further recursion.
+}

--- a/LocationDumper.h
+++ b/LocationDumper.h
@@ -1,0 +1,46 @@
+#ifndef BLANG_LOCATION_DUMPER_H_
+#define BLANG_LOCATION_DUMPER_H_
+
+#include <ostream>
+
+#include "Type.h"
+#include "Expression.h"
+
+namespace QLang
+{
+
+// Walks a parsed Module in deterministic pre-order (parent before children,
+// children in source order) and prints one line per AST node:
+//   <file>:<line>:<col> <NodeKind>
+// Used by qcc --dump-locations and as a golden-file regression lock for
+// source-location coverage (spec REQ-001). Standalone walker in the
+// BmodEmitter tradition; a friend of the AST classes so it can traverse
+// their private children.
+class LocationDumper
+{
+public:
+	static void dump( const Module *mod, std::ostream &out );
+
+private:
+	explicit LocationDumper( std::ostream &out ) : mOut( out ) {}
+
+	void visitModule( const Module *mod );
+	void visitImport( const ImportStatement *imp );
+	void visitFunction( const FunctionDefinition *func );
+	void visitVariableDef( const VariableDefinition *var );
+	void visitStruct( const StructDefinition *structDef );
+	void visitEnum( const EnumDefinition *enumDef );
+	void visitProtocol( const ProtocolDefinition *protoDef );
+	void visitTestBlock( const TestBlock *test );
+
+	// Statements and expressions (Expression derives from Statement).
+	void visitStatement( const Statement *stmt );
+
+	void emit( const SourceLocation &loc, const char *kind );
+
+	std::ostream &mOut;
+};
+
+} // namespace QLang
+
+#endif // BLANG_LOCATION_DUMPER_H_

--- a/QAssertStatement.cpp
+++ b/QAssertStatement.cpp
@@ -17,6 +17,7 @@ using namespace std;
 
 AssertStatement *AssertStatement::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_ASSERT )
 	{
@@ -24,6 +25,7 @@ AssertStatement *AssertStatement::Parse( Lexer &l, Scope *scope )
 	}
 
 	AssertStatement *stmt = new AssertStatement;
+	stmt->setLocation( loc );
 
 	stmt->mExpression = Expression::ParseExpr( l, scope, 0 );
 	if ( stmt->mExpression == nullptr )

--- a/QBlock.cpp
+++ b/QBlock.cpp
@@ -14,9 +14,11 @@ using namespace std;
 
 Block *Block::Parse( Lexer &l, Scope *block_scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	Block *block = new Block;
+	block->setLocation( loc );
 	block->mScope = block_scope;
-	
+
 	int sym = l.getSymbol();
 	if ( sym != '{' )
 	{

--- a/QBreakContinue.cpp
+++ b/QBreakContinue.cpp
@@ -17,6 +17,7 @@ using namespace std;
 
 BreakStatement *BreakStatement::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_BREAK )
 	{
@@ -29,11 +30,14 @@ BreakStatement *BreakStatement::Parse( Lexer &l, Scope *scope )
 		COMPILE_ERROR( l, "Expected ';' after break" );
 	}
 
-	return new BreakStatement;
+	BreakStatement *statement = new BreakStatement;
+	statement->setLocation( loc );
+	return statement;
 }
 
 ContinueStatement *ContinueStatement::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_CONTINUE )
 	{
@@ -46,5 +50,7 @@ ContinueStatement *ContinueStatement::Parse( Lexer &l, Scope *scope )
 		COMPILE_ERROR( l, "Expected ';' after continue" );
 	}
 
-	return new ContinueStatement;
+	ContinueStatement *statement = new ContinueStatement;
+	statement->setLocation( loc );
+	return statement;
 }

--- a/QEnumDefinition.cpp
+++ b/QEnumDefinition.cpp
@@ -21,6 +21,7 @@ EnumDefinition *EnumDefinition::Parse( Lexer &l, Scope *s, bool isPublic )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	// Consume 'enum' keyword
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_ENUM )
@@ -37,6 +38,7 @@ EnumDefinition *EnumDefinition::Parse( Lexer &l, Scope *s, bool isPublic )
 	string enumName = l.getSymbolText();
 
 	EnumDefinition *enumDef = new EnumDefinition( enumName );
+	enumDef->setLocation( loc );
 	enumDef->mIsPublic = isPublic;
 
 	// Check for generic parameters: <T> or <T: Constraint>

--- a/QEventHandler.cpp
+++ b/QEventHandler.cpp
@@ -19,6 +19,7 @@ EventHandler *EventHandler::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	// Consume 'on' keyword
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_ON )
@@ -27,6 +28,7 @@ EventHandler *EventHandler::Parse( Lexer &l, Scope *scope )
 	}
 
 	EventHandler *handler = new EventHandler;
+	handler->setLocation( loc );
 
 	// Parse the event expression (e.g., timer.every(1000))
 	handler->mEventExpression = Expression::ParseExpr( l, scope, 0 );

--- a/QExpression.cpp
+++ b/QExpression.cpp
@@ -75,6 +75,17 @@ static string getOperatorString( int sym, const string &symText )
 Expression *Expression::ParsePrimary( Lexer &l, Scope *scope )
 {
 	Expression *result = nullptr;
+	// Location of this primary's first token. Every node ParsePrimary
+	// constructs directly (unary/postfix/inline calls/literals) begins at
+	// this token; recursive sub-parses capture their own. A tiny helper
+	// stamps any node this function returns or wraps, so none escapes with
+	// an unset (0:0) location — spec FR-004.
+	SourceLocation ploc = l.getTokenLocation();
+	auto S = [&]( Expression *e ) -> Expression * {
+		if ( e != nullptr && !e->getLocation().isSet() )
+			e->setLocation( ploc );
+		return e;
+	};
 	int sym = l.peekSymbol();
 
 	// await expression: await EXPR
@@ -84,7 +95,7 @@ Expression *Expression::ParsePrimary( Lexer &l, Scope *scope )
 		Expression *operand = ParsePrimary( l, scope );
 		if ( operand == nullptr )
 			COMPILE_ERROR( l, "Expected expression after 'await'" );
-		return new AwaitExpression( operand );
+		return S( new AwaitExpression( operand ) );
 	}
 
 	// Lambda expression: fn(params) -> RetType { body }
@@ -136,7 +147,7 @@ Expression *Expression::ParsePrimary( Lexer &l, Scope *scope )
 		Expression *operand = ParsePrimary( l, scope );
 		if ( operand == nullptr )
 			COMPILE_ERROR( l, "Expected expression after unary operator" );
-		return new UnaryExpression( opStr, operand );
+		return S( new UnaryExpression( opStr, operand ) );
 	}
 
 	// Parenthesized expression
@@ -637,6 +648,10 @@ Expression *Expression::ParsePrimary( Lexer &l, Scope *scope )
 		}
 	}
 
+	// Stamp the base primary before any postfix wrapping so wrapped children
+	// keep their own location and never escape unset.
+	result = S( result );
+
 	// Postfix operators: field access (.field), method calls (.method()), indexing ([expr])
 	while ( result != nullptr )
 	{
@@ -675,11 +690,11 @@ Expression *Expression::ParsePrimary( Lexer &l, Scope *scope )
 					if ( sym != ')' )
 						COMPILE_ERROR( l, "Expected ',' or ')' in method call" );
 				}
-				result = methodCall;
+				result = S( methodCall );
 			}
 			else
 			{
-				result = new FieldAccessExpression( result, fieldName );
+				result = S( new FieldAccessExpression( result, fieldName ) );
 			}
 		}
 		else if ( l.peekSymbol() == '[' )
@@ -691,12 +706,12 @@ Expression *Expression::ParsePrimary( Lexer &l, Scope *scope )
 			int closeBracket = l.getSymbol();
 			if ( closeBracket != ']' )
 				COMPILE_ERROR( l, "Expected ']'" );
-			result = new IndexExpression( result, index );
+			result = S( new IndexExpression( result, index ) );
 		}
 		else if ( l.peekSymbol() == Lexer::QUESTION_MARK )
 		{
 			l.getSymbol(); // consume '?'
-			result = new TryExpression( result );
+			result = S( new TryExpression( result ) );
 		}
 		else
 		{
@@ -714,6 +729,15 @@ Expression *Expression::ParseExpr( Lexer &l, Scope *scope, int minPrec )
 	Expression *left = ParsePrimary( l, scope );
 	if ( left == nullptr )
 		return nullptr;
+
+	// A binary/range/pipeline node spans from the first operand's first
+	// token; give each such node the leftmost location (spec assumption).
+	SourceLocation startLoc = left->getLocation();
+	auto S = [&]( Expression *e ) -> Expression * {
+		if ( e != nullptr && !e->getLocation().isSet() )
+			e->setLocation( startLoc );
+		return e;
+	};
 
 	while ( true )
 	{
@@ -770,7 +794,7 @@ Expression *Expression::ParseExpr( Lexer &l, Scope *scope, int minPrec )
 						}
 					}
 
-					left = call;
+					left = S( call );
 				}
 				else
 				{
@@ -779,7 +803,7 @@ Expression *Expression::ParseExpr( Lexer &l, Scope *scope, int minPrec )
 					Expression *right = ParsePrimary( l, scope );
 					if ( right == nullptr )
 						COMPILE_ERROR( l, "Expected expression after '|>'" );
-					left = new PipelineExpression( left, right );
+					left = S( new PipelineExpression( left, right ) );
 				}
 			}
 			else
@@ -808,7 +832,7 @@ Expression *Expression::ParseExpr( Lexer &l, Scope *scope, int minPrec )
 			Expression *right = ParseExpr( l, scope, prec + 1 );
 			if ( right == nullptr )
 				COMPILE_ERROR( l, "Expected expression after '..'" );
-			left = new RangeExpression( left, right );
+			left = S( new RangeExpression( left, right ) );
 			continue;
 		}
 
@@ -817,7 +841,7 @@ Expression *Expression::ParseExpr( Lexer &l, Scope *scope, int minPrec )
 		if ( right == nullptr )
 			COMPILE_ERROR( l, "Expected expression after operator" );
 
-		left = new OperationsExpression( opStr, left, right );
+		left = S( new OperationsExpression( opStr, left, right ) );
 	}
 
 	return left;
@@ -853,6 +877,8 @@ Expression *Expression::Parse( Lexer &l, Scope *scope, char terminal )
 
 		if ( isAssign )
 		{
+			// The assignment node spans from the LHS's first token.
+			SourceLocation assignLoc = exp->getLocation();
 			VariableExpression *varExpr = dynamic_cast<VariableExpression*>( exp );
 			FieldAccessExpression *fieldExpr = dynamic_cast<FieldAccessExpression*>( exp );
 			IndexExpression *indexExpr = dynamic_cast<IndexExpression*>( exp );
@@ -864,6 +890,7 @@ Expression *Expression::Parse( Lexer &l, Scope *scope, char terminal )
 				if ( value == nullptr )
 					COMPILE_ERROR( l, "Expected expression after assignment operator" );
 				exp = new AssignmentExpression( assignOp, varExpr->getVariable(), value );
+				exp->setLocation( assignLoc );
 			}
 			else if ( fieldExpr != nullptr )
 			{
@@ -872,6 +899,7 @@ Expression *Expression::Parse( Lexer &l, Scope *scope, char terminal )
 				if ( value == nullptr )
 					COMPILE_ERROR( l, "Expected expression after assignment operator" );
 				exp = new FieldAssignmentExpression( assignOp, fieldExpr->getObject(), fieldExpr->getFieldName(), value );
+				exp->setLocation( assignLoc );
 			}
 			else if ( indexExpr != nullptr )
 			{
@@ -880,6 +908,7 @@ Expression *Expression::Parse( Lexer &l, Scope *scope, char terminal )
 				if ( value == nullptr )
 					COMPILE_ERROR( l, "Expected expression after assignment operator" );
 				exp = new IndexAssignmentExpression( assignOp, indexExpr->getObject(), indexExpr->getIndex(), value );
+				exp->setLocation( assignLoc );
 			}
 			else
 			{
@@ -898,6 +927,7 @@ Expression *Expression::Parse( Lexer &l, Scope *scope, char terminal )
 VariableExpression *VariableExpression::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
+	SourceLocation loc = l.getTokenLocation();
 	VariableExpression *exp = nullptr;
 	int sym = l.getSymbol();
 	if ( sym == Lexer::SYMBOL )
@@ -914,7 +944,10 @@ VariableExpression *VariableExpression::Parse( Lexer &l, Scope *scope )
 		{
 			VariableDefinition *def = dynamic_cast<VariableDefinition*>( (Symbol*)s );
 			if ( def != nullptr )
+			{
 				exp = new VariableExpression( def );
+				exp->setLocation( loc );
+			}
 		}
 	}
 
@@ -924,6 +957,7 @@ VariableExpression *VariableExpression::Parse( Lexer &l, Scope *scope )
 
 CallExpression *CallExpression::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	CallExpression *exp = nullptr;
 	int sym  = l.getSymbol();
 	if ( sym == Lexer::SYMBOL )
@@ -938,6 +972,7 @@ CallExpression *CallExpression::Parse( Lexer &l, Scope *scope )
 		{
 			FunctionDefinition *def = dynamic_cast<FunctionDefinition*>( (Symbol*)s );
 			exp = new CallExpression( def );
+			exp->setLocation( loc );
 
 			// Check for generic type arguments: fn<int>(args)
 			if ( l.peekSymbol() == '<' )
@@ -989,6 +1024,7 @@ CallExpression *CallExpression::Parse( Lexer &l, Scope *scope )
 
 ConstExpression *ConstExpression::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	ConstExpression *exp = nullptr;
 	int sym = l.getSymbol();
 	switch( sym )
@@ -1012,6 +1048,9 @@ ConstExpression *ConstExpression::Parse( Lexer &l, Scope *scope )
 		return nullptr;
 	}
 
+	if ( exp != nullptr )
+		exp->setLocation( loc );
+
 	return exp;
 }
 
@@ -1019,7 +1058,11 @@ ConstExpression *ConstExpression::Parse( Lexer &l, Scope *scope )
 // Creates alternating ConstString and VariableExpression parts.
 StringInterpolation *StringInterpolation::Parse( Lexer &l, Scope *scope, const string &rawString )
 {
+	// Interpolation parts are synthesized from the raw string; give them a
+	// real (non-zero) location near the string token (FR-004 inheritance).
+	SourceLocation loc = l.getTokenLocation();
 	StringInterpolation *interp = new StringInterpolation();
+	interp->setLocation( loc );
 	size_t pos = 0;
 
 	while ( pos < rawString.size() )
@@ -1073,6 +1116,13 @@ StringInterpolation *StringInterpolation::Parse( Lexer &l, Scope *scope, const s
 		pos = braceEnd + 1;
 	}
 
+	// Ensure every synthesized part carries a real location.
+	for ( auto &part : interp->mParts )
+	{
+		if ( part != nullptr && !part->getLocation().isSet() )
+			part->setLocation( loc );
+	}
+
 	return interp;
 }
 
@@ -1080,6 +1130,7 @@ StructLiteralExpression *StructLiteralExpression::Parse( Lexer &l, Scope *scope,
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	// Consume the struct type name
 	int sym = l.getSymbol();
 	if ( sym != Lexer::SYMBOL )
@@ -1109,6 +1160,7 @@ StructLiteralExpression *StructLiteralExpression::Parse( Lexer &l, Scope *scope,
 		COMPILE_ERROR( l, "Expected '{' in struct literal" );
 
 	StructLiteralExpression *expr = new StructLiteralExpression( typeName );
+	expr->setLocation( loc );
 
 	// Store generic type arguments if present
 	for ( auto &arg : typeArgs )

--- a/QForInStatement.cpp
+++ b/QForInStatement.cpp
@@ -22,6 +22,7 @@ ForInStatement *ForInStatement::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	// Consume 'for' keyword
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_FOR )
@@ -30,6 +31,7 @@ ForInStatement *ForInStatement::Parse( Lexer &l, Scope *scope )
 	}
 
 	ForInStatement *statement = new ForInStatement;
+	statement->setLocation( loc );
 
 	Scope *loop_scope = new Scope( Scope::kScope_Loop );
 	loop_scope->setParent( scope );

--- a/QFunctionDefinition.cpp
+++ b/QFunctionDefinition.cpp
@@ -37,6 +37,7 @@ std::ostream &QLang::operator<<(std::ostream &out, const FunctionDefinition &fun
 
 FunctionDefinition *FunctionDefinition::Parse( Lexer &l, Scope *s, bool isExtern, bool isPublic )
 {
+	SourceLocation loc = l.getTokenLocation();
 	FunctionDefinition *func;
 
 	// All function declarations use the fn keyword:
@@ -68,6 +69,7 @@ FunctionDefinition *FunctionDefinition::Parse( Lexer &l, Scope *s, bool isExtern
 		COMPILE_ERROR( l, "Expected function name after 'fn'" );
 
 	func = new FunctionDefinition( l.getSymbolText() );
+	func->setLocation( loc );
 	func->mIsExtern = isExtern;
 	func->mIsPublic = isPublic;
 	func->mIsAsync = isAsync;
@@ -248,6 +250,7 @@ FunctionDefinition *FunctionDefinition::ParseInit( Lexer &l, Scope *s )
 	// Creates a method named "init" with implicit self parameter.
 
 	FunctionDefinition *func = new FunctionDefinition( "init" );
+	func->setLocation( l.getTokenLocation() );
 	func->mIsInit = true;
 	func->mFuncScope = new Scope( Scope::kScope_Function, "init" );
 	func->mFuncScope->setParent( s );
@@ -255,6 +258,7 @@ FunctionDefinition *FunctionDefinition::ParseInit( Lexer &l, Scope *s )
 	// Add implicit self parameter
 	Type *selfType = new Type( "self" );
 	VariableDefinition *selfParam = new VariableDefinition( selfType, "self" );
+	selfParam->setLocation( func->getLocation() );
 	func->mParameters.push_back( selfParam );
 	func->mFuncScope->addSymbol( selfParam );
 

--- a/QLambdaExpression.cpp
+++ b/QLambdaExpression.cpp
@@ -12,12 +12,14 @@ LambdaExpression *LambdaExpression::Parse( Lexer &l, Scope *scope )
 {
 	// 'fn' already consumed by caller (ParsePrimary)
 
+	SourceLocation loc = l.getTokenLocation();
 	// Parse '('
 	int sym = l.getSymbol();
 	if ( sym != '(' )
 		COMPILE_ERROR( l, "Expected '(' in lambda expression" );
 
 	LambdaExpression *lambda = new LambdaExpression();
+	lambda->setLocation( loc );
 
 	// Create a child scope for the lambda body
 	SmartPtr<Scope> lambdaScope = new Scope( Scope::kScope_Function );

--- a/QMatchExpression.cpp
+++ b/QMatchExpression.cpp
@@ -19,6 +19,7 @@ MatchExpression *MatchExpression::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	// Consume 'match' keyword
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_MATCH )
@@ -27,6 +28,7 @@ MatchExpression *MatchExpression::Parse( Lexer &l, Scope *scope )
 	}
 
 	MatchExpression *expr = new MatchExpression;
+	expr->setLocation( loc );
 
 	// Parse the subject expression (a primary expression before '{')
 	expr->mSubject = Expression::ParsePrimary( l, scope );

--- a/QProtocolDefinition.cpp
+++ b/QProtocolDefinition.cpp
@@ -14,6 +14,7 @@ using namespace std;
 
 ProtocolDefinition *ProtocolDefinition::Parse( Lexer &l, Scope *s, bool isPublic )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_PROTOCOL )
 	{
@@ -27,6 +28,7 @@ ProtocolDefinition *ProtocolDefinition::Parse( Lexer &l, Scope *s, bool isPublic
 	}
 
 	ProtocolDefinition *protoDef = new ProtocolDefinition( l.getSymbolText() );
+	protoDef->setLocation( loc );
 	protoDef->mIsPublic = isPublic;
 
 	// Check for generic parameters: protocol Name<T>

--- a/QQueryExpression.cpp
+++ b/QQueryExpression.cpp
@@ -155,6 +155,7 @@ QueryExpression *QueryExpression::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol(); // consume 'query'
 	assert( sym == Lexer::KEYWORD_QUERY );
 
@@ -164,6 +165,7 @@ QueryExpression *QueryExpression::Parse( Lexer &l, Scope *scope )
 		COMPILE_ERROR( l, "Expected table name after 'query'" );
 
 	QueryExpression *expr = new QueryExpression( l.getSymbolText() );
+	expr->setLocation( loc );
 
 	// Parse pipeline steps
 	parsePipelineSteps( l, scope, expr->mSteps );
@@ -176,6 +178,7 @@ InsertExpression *InsertExpression::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol(); // consume 'insert'
 	assert( sym == Lexer::KEYWORD_INSERT );
 
@@ -185,6 +188,7 @@ InsertExpression *InsertExpression::Parse( Lexer &l, Scope *scope )
 		COMPILE_ERROR( l, "Expected table name after 'insert'" );
 
 	InsertExpression *expr = new InsertExpression( l.getSymbolText() );
+	expr->setLocation( loc );
 
 	// Expect '{' for field assignments
 	sym = l.getSymbol();
@@ -227,6 +231,7 @@ UpdateExpression *UpdateExpression::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol(); // consume 'update'
 	assert( sym == Lexer::KEYWORD_UPDATE );
 
@@ -236,6 +241,7 @@ UpdateExpression *UpdateExpression::Parse( Lexer &l, Scope *scope )
 		COMPILE_ERROR( l, "Expected table name after 'update'" );
 
 	UpdateExpression *expr = new UpdateExpression( l.getSymbolText() );
+	expr->setLocation( loc );
 
 	// Parse pipeline steps (where, set)
 	parsePipelineSteps( l, scope, expr->mSteps );
@@ -248,6 +254,7 @@ DeleteExpression *DeleteExpression::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol(); // consume 'delete'
 	assert( sym == Lexer::KEYWORD_DELETE );
 
@@ -257,6 +264,7 @@ DeleteExpression *DeleteExpression::Parse( Lexer &l, Scope *scope )
 		COMPILE_ERROR( l, "Expected table name after 'delete'" );
 
 	DeleteExpression *expr = new DeleteExpression( l.getSymbolText() );
+	expr->setLocation( loc );
 
 	// Parse pipeline steps (where)
 	parsePipelineSteps( l, scope, expr->mSteps );

--- a/QReturnStatement.cpp
+++ b/QReturnStatement.cpp
@@ -14,14 +14,16 @@ using namespace std;
 
 ReturnStatement *ReturnStatement::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	ReturnStatement *statement = nullptr;
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_RETURN )
 	{
 		COMPILE_ERROR( l, "Internal Error" );
 	}
-	
+
 	statement = new ReturnStatement;
+	statement->setLocation( loc );
 
 	// Check for bare 'return;' (void return)
 	if ( l.peekSymbol() == ';' )

--- a/QSpawnStatement.cpp
+++ b/QSpawnStatement.cpp
@@ -19,6 +19,7 @@ SpawnStatement *SpawnStatement::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	// Consume 'spawn' keyword
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_SPAWN )
@@ -27,6 +28,7 @@ SpawnStatement *SpawnStatement::Parse( Lexer &l, Scope *scope )
 	}
 
 	SpawnStatement *statement = new SpawnStatement;
+	statement->setLocation( loc );
 
 	// Create anonymous scope for spawn body
 	Scope *spawn_scope = new Scope( Scope::kScope_Anonymous );
@@ -49,6 +51,7 @@ WaitStatement *WaitStatement::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	// Consume 'wait' keyword
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_WAIT )
@@ -57,6 +60,7 @@ WaitStatement *WaitStatement::Parse( Lexer &l, Scope *scope )
 	}
 
 	WaitStatement *statement = new WaitStatement;
+	statement->setLocation( loc );
 
 	// Parse the expression (Task variable to wait on)
 	statement->mExpr = Expression::ParseExpr( l, scope, 0 );
@@ -81,6 +85,7 @@ WaitAllStatement *WaitAllStatement::Parse( Lexer &l, Scope *scope )
 {
 	TRACE_BEGIN( LOG_LVL_INFO );
 
+	SourceLocation loc = l.getTokenLocation();
 	// Consume 'wait_all' keyword
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_WAIT_ALL )
@@ -89,6 +94,7 @@ WaitAllStatement *WaitAllStatement::Parse( Lexer &l, Scope *scope )
 	}
 
 	WaitAllStatement *statement = new WaitAllStatement;
+	statement->setLocation( loc );
 
 	// Expect semicolon
 	sym = l.getSymbol();

--- a/QStructDefinition.cpp
+++ b/QStructDefinition.cpp
@@ -14,6 +14,7 @@ using namespace std;
 
 StructDefinition *StructDefinition::Parse( Lexer &l, Scope *s, bool isPublic )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_STRUCT )
 	{
@@ -27,6 +28,7 @@ StructDefinition *StructDefinition::Parse( Lexer &l, Scope *s, bool isPublic )
 	}
 
 	StructDefinition *structDef = new StructDefinition( l.getSymbolText() );
+	structDef->setLocation( loc );
 	structDef->mIsPublic = isPublic;
 
 	// Check for generic parameters: struct Name<T> or struct Name<T: Constraint>
@@ -72,6 +74,7 @@ StructDefinition *StructDefinition::Parse( Lexer &l, Scope *s, bool isPublic )
 
 	while ( l.peekSymbol() != '}' )
 	{
+		SourceLocation fieldLoc = l.getTokenLocation();
 		SmartPtr<Type> fieldType = Type::Parse( l, s, false );
 		if ( fieldType == nullptr )
 		{
@@ -89,6 +92,7 @@ StructDefinition *StructDefinition::Parse( Lexer &l, Scope *s, bool isPublic )
 		}
 
 		VariableDefinition *field = new VariableDefinition( fieldType, l.getSymbolText() );
+		field->setLocation( fieldLoc );
 		structDef->mFields.push_back( field );
 
 		sym = l.getSymbol();

--- a/QTestBlock.cpp
+++ b/QTestBlock.cpp
@@ -17,6 +17,7 @@ using namespace std;
 
 TestBlock *TestBlock::Parse( Lexer &l, Scope *s )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_TEST )
 	{
@@ -35,6 +36,7 @@ TestBlock *TestBlock::Parse( Lexer &l, Scope *s )
 	testScope->setParent( s );
 
 	TestBlock *testBlock = new TestBlock( name );
+	testBlock->setLocation( loc );
 
 	testBlock->mBody = Block::Parse( l, testScope );
 

--- a/QVariableDefinition.cpp
+++ b/QVariableDefinition.cpp
@@ -20,6 +20,7 @@ std::ostream &QLang::operator<<(std::ostream &out, const VariableDefinition &var
 
 VariableDefinition *VariableDefinition::ParseFuncParam( Lexer &l, Scope *s, bool isExtern, int paramIndex )
 {
+	SourceLocation loc = l.getTokenLocation();
 	VariableDefinition *def = nullptr;
 
 	// Handle 'self' parameter specially — it has an implicit type
@@ -28,6 +29,7 @@ VariableDefinition *VariableDefinition::ParseFuncParam( Lexer &l, Scope *s, bool
 		l.getSymbol(); // consume 'self'
 		SmartPtr<Type> selfType = new Type( "self" );
 		def = new VariableDefinition( selfType, "self" );
+		def->setLocation( loc );
 		s->addSymbol( def );
 		return def;
 	}
@@ -85,12 +87,17 @@ VariableDefinition *VariableDefinition::ParseFuncParam( Lexer &l, Scope *s, bool
 	if ( def != nullptr && ownership != OwnershipQualifier::kOwnership_Value )
 		def->setOwnership( ownership );
 
+	if ( def != nullptr )
+		def->setLocation( loc );
+
 	return def;
 }
 
 VariableDeclaration *VariableDeclaration::Parse( Lexer &l, Scope *s )
 {
+	SourceLocation loc = l.getTokenLocation();
 	VariableDeclaration *def = new VariableDeclaration;
+	def->setLocation( loc );
 	bool isConst = false;
 	bool isVar = false;
 	OwnershipQualifier ownership = OwnershipQualifier::kOwnership_Value;
@@ -155,6 +162,7 @@ VariableDeclaration *VariableDeclaration::Parse( Lexer &l, Scope *s )
 			data.mVaribale = new VariableDefinition( t, l.getSymbolText() );
 			data.mVaribale->setConst( isConst );
 			data.mVaribale->setOwnership( ownership );
+			data.mVaribale->setLocation( loc );
 		}
 		else
 		{

--- a/SourceLocation.h
+++ b/SourceLocation.h
@@ -1,0 +1,24 @@
+#ifndef BLANG_SOURCE_LOCATION_H_
+#define BLANG_SOURCE_LOCATION_H_
+
+#include <cstdint>
+#include <string>
+
+// A source position: file name plus 1-based line and column of a token's
+// first character. Default-constructed state (line == 0, col == 0) means
+// "unset" and must never escape the parser onto a reachable AST node
+// (see spec FR-004). Plain value type — freely copyable, no RefCount.
+struct SourceLocation
+{
+	std::string file;
+	uint32_t line = 0;
+	uint32_t col = 0;
+
+	SourceLocation() {}
+	SourceLocation( const std::string &f, uint32_t l, uint32_t c ) :
+		file( f ), line( l ), col( c ) {}
+
+	bool isSet() const { return line != 0 && col != 0; }
+};
+
+#endif // BLANG_SOURCE_LOCATION_H_

--- a/Type.h
+++ b/Type.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "RefCount.h"
+#include "SourceLocation.h"
 
 //#include "Expression.h"
 
@@ -31,9 +32,17 @@ namespace QLang
 
 		static Statement *Parse( Lexer &l, Scope *scope );
 
+		// Source location of the construct's first token, stamped at parse
+		// time. Every reachable AST node carries a set location (line/col
+		// >= 1); see spec REQ-001 / FR-003.
+		void setLocation( const SourceLocation &loc ) { mLocation = loc; }
+		const SourceLocation &getLocation() const { return mLocation; }
+
 	protected:
 		Statement() {}
+		SourceLocation mLocation;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class Type : virtual public RefCount
@@ -51,11 +60,16 @@ namespace QLang
 
 		virtual bool isFunctionType() const { return false; }
 
+		void setLocation( const SourceLocation &loc ) { mLocation = loc; }
+		const SourceLocation &getLocation() const { return mLocation; }
+
 		friend std::ostream &operator<<(std::ostream &out, const Type &type);
 
 	private:
 		std::string mName;
 		std::vector<SmartPtr<Type>> mTypeParams;
+		SourceLocation mLocation;
+		friend class LocationDumper;
 	};
 
 	class FunctionType : public Type
@@ -76,6 +90,7 @@ namespace QLang
 		SmartPtr<Type> mReturnType;  // nullptr = void
 		std::vector<SmartPtr<Type>> mParamTypes;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class Symbol : virtual public RefCount
@@ -94,8 +109,13 @@ namespace QLang
 
 		virtual SymbolType getSymbolType() = 0;
 
+		void setLocation( const SourceLocation &loc ) { mLocation = loc; }
+		const SourceLocation &getLocation() const { return mLocation; }
+
 	private:
 		std::string mName;
+		SourceLocation mLocation;
+		friend class LocationDumper;
 	};
 
 	class Scope : virtual public RefCount
@@ -223,8 +243,13 @@ namespace QLang
 
 		const std::string &getModuleName() const { return mModuleName; }
 
+		void setLocation( const SourceLocation &loc ) { mLocation = loc; }
+		const SourceLocation &getLocation() const { return mLocation; }
+
 	private:
 		std::string mModuleName;
+		SourceLocation mLocation;
+		friend class LocationDumper;
 	};
 
 	class StructDefinition;
@@ -249,6 +274,7 @@ namespace QLang
 	private:
 		Module() {}
 		friend class CodeGen;
+		friend class LocationDumper;
 
 		std::vector<SmartPtr<FunctionDefinition> > mFunctionList;
 		std::vector<SmartPtr<ImportStatement>> mImports;
@@ -325,6 +351,7 @@ namespace QLang
 		std::vector<AnnotationNode> mAnnotations;
 
 		friend class CodeGen;
+		friend class LocationDumper;
 		friend class Module;
 	};
 
@@ -401,6 +428,7 @@ namespace QLang
 		bool mIsPublic = false;
 		bool mIsTable = false;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class ProtocolDefinition : public Symbol
@@ -434,6 +462,7 @@ namespace QLang
 		std::vector<GenericParam> mGenericParams;
 		bool mIsPublic = false;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class EnumDefinition : public Symbol
@@ -468,6 +497,7 @@ namespace QLang
 		std::vector<AnnotationNode> mAnnotations;
 		bool mIsPublic = false;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 	class TestBlock : virtual public RefCount
@@ -479,10 +509,15 @@ namespace QLang
 
 		const std::string &getName() const { return mName; }
 
+		void setLocation( const SourceLocation &loc ) { mLocation = loc; }
+		const SourceLocation &getLocation() const { return mLocation; }
+
 	private:
 		std::string mName;
 		SmartPtr<Block> mBody;
+		SourceLocation mLocation;
 		friend class CodeGen;
+		friend class LocationDumper;
 	};
 
 };

--- a/qcc.cpp
+++ b/qcc.cpp
@@ -13,6 +13,7 @@
 #include "logging.h"
 
 #include "BmodEmitter.h"
+#include "LocationDumper.h"
 
 #ifdef BLANG_HAS_LLVM
 #include "CodeGen.h"
@@ -26,9 +27,13 @@ Scope *gScope;
 
 string CompileError::getMessage() const
 {
+	// Token-accurate line comes from the snapshotted location, not the live
+	// lexer. The user-facing message SHAPE is unchanged here; reformatting
+	// to <file>:<line>:<col>: error: is U2's scope (FR-005). The compiler's
+	// own __FILE__:__LINE__ is retained for a future --debug-compiler mode.
 	stringstream s;
-	s << "Compiler Error in " << mFilename << ":" << mLineno << endl;
-	s << mMessage << " at line: " << mLexer.getLineNumber();
+	s << "Compiler Error in " << getInternalFile() << ":" << getInternalLine() << endl;
+	s << mMessage << " at line: " << mLocation.line;
 	return s.str();
 }
 
@@ -52,6 +57,7 @@ Module *Module::Parse( Lexer &l, Scope *s )
 			// Handle import statements
 			if ( nextSym == Lexer::KEYWORD_IMPORT )
 			{
+				SourceLocation importLoc = l.getTokenLocation();
 				l.getSymbol(); // consume 'import'
 				int importSym = l.getSymbol();
 				if ( importSym != Lexer::SYMBOL )
@@ -74,7 +80,11 @@ Module *Module::Parse( Lexer &l, Scope *s )
 				if ( semi != ';' )
 					COMPILE_ERROR( l, "Expected ';' after import statement" );
 
-				mod->mImports.push_back( new ImportStatement( moduleName ) );
+				{
+					ImportStatement *imp = new ImportStatement( moduleName );
+					imp->setLocation( importLoc );
+					mod->mImports.push_back( imp );
+				}
 
 				// Validate and register the import for qualified access
 				Scope *ns = s->findNamespace( moduleName );
@@ -291,6 +301,7 @@ Module *Module::Parse( Lexer &l, Scope *s )
 
 WhileStatement *WhileStatement::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_WHILE )
 	{
@@ -298,6 +309,7 @@ WhileStatement *WhileStatement::Parse( Lexer &l, Scope *scope )
 	}
 
 	WhileStatement *statement = new WhileStatement;
+	statement->setLocation( loc );
 
 	statement->mLoopExpression = Expression::ParseExpr( l, scope, 0 );
 
@@ -319,6 +331,7 @@ WhileStatement *WhileStatement::Parse( Lexer &l, Scope *scope )
 
 IfStatement *IfStatement::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_IF )
 	{
@@ -326,6 +339,7 @@ IfStatement *IfStatement::Parse( Lexer &l, Scope *scope )
 	}
 
 	IfStatement *statement = new IfStatement;
+	statement->setLocation( loc );
 
 	statement->mIfExpression = Expression::ParseExpr( l, scope, 0 );
 
@@ -359,6 +373,7 @@ IfStatement *IfStatement::Parse( Lexer &l, Scope *scope )
 
 ForStatement *ForStatement::Parse( Lexer &l, Scope *scope )
 {
+	SourceLocation loc = l.getTokenLocation();
 	int sym = l.getSymbol();
 	if ( sym != Lexer::KEYWORD_FOR )
 	{
@@ -372,6 +387,7 @@ ForStatement *ForStatement::Parse( Lexer &l, Scope *scope )
 	}
 
 	ForStatement *statement = new ForStatement;
+	statement->setLocation( loc );
 
 	statement->mInitialExpression = Expression::Parse( l, scope );
 	if ( statement->mInitialExpression == nullptr )
@@ -413,6 +429,7 @@ static void printUsage( const char *progName )
 	std::cerr << "  --parse-only      Parse only, no code generation" << std::endl;
 	std::cerr << "  --combine         Combine all .b files into a single .ll output" << std::endl;
 #endif
+	std::cerr << "  --dump-locations  Print <file>:<line>:<col> <NodeKind> per AST node and exit" << std::endl;
 	std::cerr << "  --emit-bmod FILE  Emit .bmod interface file" << std::endl;
 	std::cerr << "  -h, --help        Show this help" << std::endl;
 }
@@ -429,6 +446,7 @@ int main( int argc, char *argv[] )
 	bool emitObj = false;
 	bool parseOnly = false;
 	bool combineMode = false;
+	bool dumpLocations = false;
 	std::string outputFile;
 	std::string emitBmodFile;
 	std::vector<std::string> inputFiles;
@@ -442,6 +460,13 @@ int main( int argc, char *argv[] )
 			emitObj = true;
 		else if ( arg == "--parse-only" )
 			parseOnly = true;
+		else if ( arg == "--dump-locations" )
+		{
+			// Print one <file>:<line>:<col> <NodeKind> line per AST node,
+			// then exit. Implies parse-only; no LLVM dependency.
+			dumpLocations = true;
+			parseOnly = true;
+		}
 		else if ( arg == "--combine" )
 			combineMode = true;
 		else if ( arg == "--emit-bmod" )
@@ -560,6 +585,15 @@ int main( int argc, char *argv[] )
 		combineScope->setParent( gScope );
 	}
 
+	// In --dump-locations mode the only output is the location dump. Divert
+	// the parser's informational stdout to a discard sink during parsing;
+	// it is restored before the dump is written. (Global quiet-by-default
+	// is U2's scope; this is the minimal carve-out so the dump is clean.)
+	std::ostringstream dumpDiscardSink;
+	std::streambuf *savedCoutBuf = nullptr;
+	if ( dumpLocations )
+		savedCoutBuf = std::cout.rdbuf( dumpDiscardSink.rdbuf() );
+
 	for ( std::size_t fileIdx = 0; fileIdx < inputFiles.size(); fileIdx++ )
 	{
 		const auto &inputFile = inputFiles[fileIdx];
@@ -657,6 +691,8 @@ int main( int argc, char *argv[] )
 
 		LexerReader reader( inputFile.c_str() );
 		Lexer l( &reader );
+		if ( dumpLocations )
+			l.setTraceEnabled( false );
 
 		SmartPtr<Module> mod = Module::Parse( l, fileScope );
 		if ( mod == nullptr )
@@ -679,6 +715,20 @@ int main( int argc, char *argv[] )
 
 		modules.push_back( mod );
 		cout << "Completed parse" << endl;
+	}
+
+	// --dump-locations: restore stdout and print one line per AST node for
+	// each parsed source module (command-line order), then exit. This is
+	// the entire stdout of a dump run.
+	if ( dumpLocations )
+	{
+		std::cout.rdbuf( savedCoutBuf );
+		for ( auto &mod : modules )
+		{
+			if ( !mod->isExtern() )
+				LocationDumper::dump( (Module*)mod, std::cout );
+		}
+		return 0;
 	}
 
 	// Emit .bmod interface file if requested (runs after parsing, before codegen)

--- a/specs/001-source-locations/checklists/requirements.md
+++ b/specs/001-source-locations/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Source Locations End to End (U1)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This is a compiler-internal unit: the "user" is the compiler developer and
+  downstream epic units (U2/U3+); user value is stated in those terms, and
+  named source artifacts (FileLexer.cpp, CompileError, Parse methods) appear
+  because they are the epic workplan's own vocabulary for the unit's scope —
+  they identify WHERE the capability lives, not HOW to build it.
+- Column convention, dump order, and node-kind naming were resolved as
+  recorded Assumptions (golden files serve as the arbiter) rather than left
+  as clarifications, per epic guidance that ambiguities be closed and
+  recorded.
+- All items pass; ready for /speckit-plan.

--- a/specs/001-source-locations/contracts/dump-locations-cli.md
+++ b/specs/001-source-locations/contracts/dump-locations-cli.md
@@ -1,0 +1,69 @@
+# Contract: `qcc --dump-locations` (U1)
+
+## Invocation
+
+```
+qcc --dump-locations <file.b> [<file2.b> ...]
+```
+
+- Available in BOTH build modes (LLVM and `BLANG_ENABLE_LLVM=OFF`); no LLVM
+  dependency.
+- Implies parse-only: no `.ll`/`.o`/`.bmod` output, no codegen.
+- Listed in `--help` output.
+
+## Output (stdout)
+
+Exactly one line per AST node of each successfully parsed input file, and
+nothing else:
+
+```
+<file>:<line>:<col> <NodeKind>
+```
+
+Grammar of a line (locked by golden files):
+
+- `<file>` — the input path verbatim as passed on the command line.
+- `<line>` — decimal integer ≥ 1 (1-based).
+- `<col>` — decimal integer ≥ 1 (1-based; each consumed source character
+  counts one column, tabs included).
+- single space separator.
+- `<NodeKind>` — the node's class name without namespace
+  (`FunctionDefinition`, `Block`, `ReturnStatement`, `ConstInteger`, ...).
+
+Order: deterministic pre-order — parent before children, children in
+source order; multiple input files dump in command-line order.
+
+## Exit status
+
+- 0 — all inputs parsed; dump complete.
+- non-zero — parse error; error text goes to stderr (existing error path),
+  stdout contains only the dump lines emitted before the failing file.
+
+## Determinism
+
+Two runs of the same binary on the same input produce byte-identical
+stdout. No timestamps, pointers, or environment-dependent content.
+
+## Acceptance commands (from the unit's done-when; run from repo root)
+
+```bash
+build/qcc --dump-locations test_files/pass/func_simple.b \
+  | diff - test_files/golden/func_simple.locations          # exits 0
+
+build/qcc --dump-locations test_files/pass/match_basic.b \
+  | diff - test_files/golden/match_basic.locations           # exits 0
+
+# no unset locations in either dump:
+build/qcc --dump-locations test_files/pass/func_simple.b | grep -E ':0:[0-9]+ |:[0-9]+:0 ' && exit 1 || true
+build/qcc --dump-locations test_files/pass/match_basic.b  | grep -E ':0:[0-9]+ |:[0-9]+:0 ' && exit 1 || true
+```
+
+## Internal API contracts consumed by later units
+
+- `Lexer::getTokenLocation() -> SourceLocation` — position of the token at
+  the current parse position; accurate after `setCurrentPos` backtracking.
+- `Statement::getLocation()`, `Symbol::getLocation()`, `Type::getLocation()`
+  — stamped on every parsed node; line/col ≥ 1.
+- `CompileError::getLocation() -> SourceLocation` — frozen at throw time;
+  reporting does not touch the lexer. (U2 formats
+  `<file>:<line>:<col>: error: <message>` from exactly this value.)

--- a/specs/001-source-locations/data-model.md
+++ b/specs/001-source-locations/data-model.md
@@ -1,0 +1,105 @@
+# Data Model: Source Locations End to End (U1)
+
+**Feature**: specs/001-source-locations/spec.md
+**Date**: 2026-07-13
+
+## Entities
+
+### SourceLocation (new value type — `SourceLocation.h`)
+
+| Field | Type | Meaning | Validity |
+|-------|------|---------|----------|
+| file | std::string | Source file path as given on the qcc command line | non-empty for parsed nodes |
+| line | uint32_t | 1-based line of the token's first character | ≥ 1 on every parsed node (0 = "unset", must never escape the parser) |
+| col | uint32_t | 1-based column of the token's first character; every consumed character (incl. tab, `\r`) counts 1 | ≥ 1 on every parsed node |
+
+Plain value type. No RefCount, freely copyable. Default-constructed state
+(0,0) exists only as "not yet stamped"; FR-004 forbids it on any node
+reachable from a successfully parsed module.
+
+### Token position record (extension of `Lexer::SymbolInfo`, FileLexer.h)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| symbol | int | existing |
+| symbolText | std::string | existing |
+| line | uint32_t | NEW — line of token's first character, captured at scan time |
+| col | uint32_t | NEW — column of token's first character, captured at scan time |
+
+Invariant: positions are recorded exactly once (when the token is scanned
+from the file) and are immutable thereafter; replay and backtracking
+(`setCurrentPos`) read them back unchanged. This is what makes locations
+backtracking-proof (research R1).
+
+### Reader counters (extension of `LexerReader`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| mFileName | std::string | NEW — retained from constructor |
+| mLine | uint32_t | NEW — starts 1; `popChar()` of `'\n'` increments and resets mCol |
+| mCol | uint32_t | NEW — starts 1; every `popChar()` advances by 1 |
+
+Invariant: counters reflect the position of the **next unconsumed
+character**. All consumption goes through `popChar`/`popChar(int)`
+(research R2), so multi-line strings and block comments are counted
+correctly.
+
+### Lexer position API (extension of `Lexer`)
+
+| Member | Meaning |
+|--------|---------|
+| `getTokenLocation()` | SourceLocation of the token at the current parse position — the token the parser is about to consume (or just peeked). Defined against `mCurrentPos`/`mSymbolList`, NOT the file read-ahead. |
+| `getFileName()` | The source file this lexer is scanning. |
+| `setTraceEnabled(bool)` | NEW — gates the per-token stdout echo (default: current behavior). See research R7. |
+| `getLineNumber()` / `getLinePosition()` | Retained; become token-accurate (delegate to the current token's record). |
+
+### AST node location (extension of `Statement`, `Symbol`, `Type` bases in Type.h)
+
+| Member | Meaning |
+|--------|---------|
+| `mLocation` : SourceLocation | Location of the construct's **first token**. Stamped at parse time by every `Parse` factory (capture-at-entry, research R4). |
+| `setLocation(const SourceLocation&)` / `getLocation()` | Public accessors used by parser, dumper, and downstream units (U2 diagnostics, U3 sema). |
+
+Relationships: every class deriving from `Statement` (all statements and
+expressions in Expression.h), from `Symbol` (FunctionDefinition,
+VariableDefinition, StructDefinition, EnumDefinition, ProtocolDefinition),
+and `Type`/`FunctionType` carries exactly one SourceLocation. Desugared/
+synthesized nodes inherit the location of their originating construct.
+
+### CompileError (modified — CompilerHelpers.h)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| mLocation | SourceLocation | NEW — snapshot of `l.getTokenLocation()` taken by `COMPILE_ERROR` at throw time |
+| mMessage | std::string | existing |
+| mFilename / mLineno | const char* / int | existing C++ `__FILE__`/`__LINE__`; retained for U2's `--debug-compiler`, not part of the location contract |
+| ~~mLexer~~ | Lexer& | REMOVED from the reporting path — reporting must not read the live lexer (FR-005) |
+
+State transition: constructed (location frozen) → propagated → reported.
+The reported line number is `mLocation.line` (token-accurate).
+
+### Location dump line (output contract of `--dump-locations`)
+
+```
+<file>:<line>:<col> <NodeKind>\n
+```
+
+- `<file>` — path exactly as given on the command line.
+- `<line>`, `<col>` — decimal, no padding, both ≥ 1.
+- `<NodeKind>` — node's C++ class name, `QLang::` prefix stripped
+  (e.g. `FunctionDefinition`, `IfStatement`, `ConstInteger`).
+- Order — pre-order traversal: parent before children, children in source
+  order; per input file, files in command-line order.
+- The dump is the **entire** stdout of a `--dump-locations` run
+  (research R7); exit 0 on successful parse.
+
+### Golden files (new test assets)
+
+| File | Locks |
+|------|-------|
+| `test_files/golden/func_simple.locations` | dump of `test_files/pass/func_simple.b` |
+| `test_files/golden/match_basic.locations` | dump of `test_files/pass/match_basic.b` (backtracking-heavy constructs) |
+
+Byte-exact regression locks for: position convention (1-based, tab = 1),
+node-location = first-token rule, pre-order dump order, NodeKind names.
+Hand-verified once at creation (research R8).

--- a/specs/001-source-locations/plan.md
+++ b/specs/001-source-locations/plan.md
@@ -1,0 +1,145 @@
+# Implementation Plan: Source Locations End to End (U1)
+
+**Branch**: `epic/blang-ast/u1-source-locations` | **Date**: 2026-07-13 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `specs/001-source-locations/spec.md`
+(epic blang-ast, unit U1, REQ-001)
+
+## Summary
+
+Give every AST node an accurate `SourceLocation {file, line, col}`. Line/
+column counting moves into `LexerReader::popChar()` (covering multi-line
+tokens); per-token positions are frozen into the lexer's `SymbolInfo` replay
+list so parser backtracking cannot desynchronize them; every `Parse` factory
+stamps its node with the location of the construct's first token;
+`CompileError` snapshots the location at throw time instead of reading the
+live lexer. A new `qcc --dump-locations` flag renders a deterministic
+pre-order `<file>:<line>:<col> <NodeKind>` dump, locked by two committed
+golden files. No change to which programs are accepted or rejected; all
+suites stay green in both build modes. Full decisions with rationale:
+[research.md](research.md) R1–R8.
+
+## Technical Context
+
+**Language/Version**: C++17 (house style: tabs, Allman, `m`-prefix members — CLAUDE.md)
+
+**Primary Dependencies**: none for this unit (LLVM 18 remains optional; the
+new flag and all location plumbing are LLVM-independent — FR-009)
+
+**Storage**: N/A (two committed golden text files under `test_files/golden/`)
+
+**Testing**: `./run_tests.sh` (162 parse tests), `./test_codegen.sh` (63 E2E),
+parse-only suite via `BUILD_DIR=build-parse ./run_tests.sh`, plus the U1
+golden-diff commands (evaluation.md §Unit-specific checks)
+
+**Target Platform**: Linux (CI), macOS supported; Itanium C++ ABI assumed for
+`typeid` demangling (research R6)
+
+**Project Type**: compiler (single CMake project, sources at repo root)
+
+**Performance Goals**: no measurable compile-time regression; location
+tracking is O(1) per character/token
+
+**Constraints**: parser shape frozen (`Parse(Lexer&, Scope*)` factories,
+SmartPtr, QLang namespace — design.md seam); accepted/rejected program set
+unchanged; default-mode console output unchanged except where
+`--dump-locations` is active (research R7); user-visible error *format*
+redesign deferred to U2
+
+**Scale/Scope**: ~30 `Q*.cpp` parser files stamp locations; 3 AST base
+classes gain a member; 1 new header, 1 new walker class, 1 new CLI flag,
+2 golden files; ~413 `COMPILE_ERROR` sites migrate via a single macro change
+
+## Constitution Check
+
+*GATE: evaluated against `.specify/memory/constitution.md` v1.1.0.*
+
+| Principle | Assessment | Status |
+|-----------|------------|--------|
+| I — One Right Way / spec fidelity | No language syntax/semantics change. `CLAUDE.md` gains `--dump-locations` in CLI features (task included). `docs/language_design.md` untouched — no semantic change to document. | PASS |
+| II — Test-Gated Changes | Not a language feature — an internal capability + CLI flag; its tests are the two golden diffs + determinism checks (this unit's done-when), run as per-unit gates. No new pass/fail/codegen tests required because accepted/rejected behavior is intentionally unchanged; full suites must stay green in both modes (Gate A/B). | PASS |
+| III — Reject, Don't Coerce | No new coercion or silent-drop paths; groundwork FOR located diagnostics. Compiler-internal `__FILE__:__LINE__` retained in `CompileError` but its user-visible demotion is U2's mandate (workplan). | PASS |
+| IV — Memory/Thread Safety | No `runtime/*.c` or ARC/ownership codegen changes → leak-check gate not triggered. | PASS (N/A) |
+| V — House Style | New code follows tabs/Allman/`m`-prefix/PascalCase headers; `LocationDumper` mirrors `BmodEmitter` precedent. | PASS |
+
+**Post-design re-check** (after Phase 1 artifacts): no violations introduced;
+Complexity Tracking empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-source-locations/
+├── spec.md              # /speckit-specify output
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions R1..R8
+├── data-model.md        # Phase 1 — SourceLocation, SymbolInfo, node/CompileError shapes
+├── quickstart.md        # Phase 1 — validation runbook
+├── contracts/
+│   └── dump-locations-cli.md   # CLI + dump-line grammar + internal API contracts
+├── checklists/
+│   └── requirements.md  # spec quality checklist (all pass)
+└── tasks.md             # /speckit-tasks output
+```
+
+### Source Code (repository root — flat layout, existing convention)
+
+```text
+SourceLocation.h         # NEW — SourceLocation value struct
+FileLexer.h / FileLexer.cpp      # SymbolInfo {+line,+col}; token-position capture;
+                                 #   getTokenLocation(); setTraceEnabled(); trace gating
+LexerReader.cpp / FileLexer.h    # LexerReader {+mFileName,+mLine,+mCol}; counting in popChar
+Type.h                   # Statement/Symbol/Type bases gain mLocation + accessors
+Expression.h             # (nodes inherit from Statement — no per-class edits expected)
+CompilerHelpers.h        # CompileError {+mLocation, -mLexer}; COMPILE_ERROR macro snapshots
+qcc.cpp                  # --dump-locations flag; CompileError::getMessage() reads mLocation;
+                         #   dump-mode output suppression (research R7)
+Q*.cpp (~30 files)       # every Parse factory stamps node locations (capture-at-entry)
+LocationDumper.h / LocationDumper.cpp   # NEW — pre-order location dump walker
+CMakeLists.txt           # add LocationDumper.cpp (+ SourceLocation.h header-only) to qcc target
+CLAUDE.md                # document --dump-locations (constitution I)
+test_files/golden/func_simple.locations   # NEW golden
+test_files/golden/match_basic.locations   # NEW golden
+```
+
+**Structure Decision**: keep the repository's flat single-project layout;
+one new header + one new walker class pair, everything else edits in place.
+No new directories except `test_files/golden/`.
+
+## Implementation strategy (maps research → code)
+
+1. **Reader counters** (R2): `LexerReader` retains filename, counts
+   line/col in `popChar`; expose getters. Fixes multi-line-token line drift
+   as a side effect.
+2. **Per-token positions** (R1): `Lexer` snapshots reader position at
+   token-recognition start into widened `SymbolInfo {symbol, text, line,
+   col}`; `getTokenLocation()` reads the record at `mCurrentPos` (peek/get
+   consistent; correct after `setCurrentPos`). `getLineNumber()` delegates
+   to the current token record.
+3. **Node stamping** (R3, R4): `SourceLocation.h`; `mLocation` +
+   accessors on `Statement`, `Symbol`, `Type`; each `Parse` factory
+   captures `l.getTokenLocation()` at entry and stamps every node it
+   constructs; desugared nodes inherit their construct's location.
+4. **CompileError** (R5): macro snapshots location at throw; reporting
+   (`getMessage`, qcc.cpp) uses the stored location; live-lexer dependency
+   removed. Message shape otherwise unchanged (U2 owns format).
+5. **Dumper + flag** (R6, R7): `LocationDumper` pre-order walker with
+   `typeid`-demangled NodeKinds; `--dump-locations` flag implies
+   parse-only, suppresses non-dump stdout (lexer trace gate + qcc info
+   prints) so stdout is exactly the dump.
+6. **Goldens + docs** (R8): generate, hand-verify every line against the
+   source, commit; update CLAUDE.md; run Gates A/B + unit-specific diffs.
+
+## Verification (per-unit gates — evaluation.md)
+
+```bash
+# Gate A: LLVM build + full suites; Gate B: parse-only build + suite
+# (commands in quickstart.md)
+# U1-specific: both golden diffs exit 0; no :0 line/col in dumps;
+# determinism and build-mode parity diffs empty.
+```
+
+## Complexity Tracking
+
+*No constitution violations — table intentionally empty.*

--- a/specs/001-source-locations/plan.md
+++ b/specs/001-source-locations/plan.md
@@ -48,7 +48,7 @@ redesign deferred to U2
 
 **Scale/Scope**: ~30 `Q*.cpp` parser files stamp locations; 3 AST base
 classes gain a member; 1 new header, 1 new walker class, 1 new CLI flag,
-2 golden files; ~413 `COMPILE_ERROR` sites migrate via a single macro change
+2 golden files; ~215 `COMPILE_ERROR` sites migrate via a single macro change
 
 ## Constitution Check
 

--- a/specs/001-source-locations/quickstart.md
+++ b/specs/001-source-locations/quickstart.md
@@ -41,6 +41,16 @@ diff <(build/qcc --dump-locations test_files/pass/match_basic.b) \
 diff <(build/qcc --dump-locations test_files/pass/match_basic.b) \
      <(build-parse/qcc --dump-locations test_files/pass/match_basic.b)
 
+# 4b. Corpus-wide FR-004 smoke check: no AST node in ANY pass file has a
+#     zero line/col (goes beyond the two goldens).
+fail=0
+for f in test_files/pass/*.b; do
+  if build/qcc --dump-locations "$f" 2>/dev/null \
+       | grep -qE ':0:[0-9]+ |:[0-9]+:0 '; then
+    echo "ZERO-LOC in $f"; fail=1
+  fi
+done; test "$fail" -eq 0 && echo "corpus: no zero locations"
+
 # 5. Token-accurate error locations (behavioral spot check): a fail-suite
 #    file still fails, and the reported line matches the offending token
 build/qcc test_files/fail/missing_brace.b; echo "exit=$? (expect non-zero)"

--- a/specs/001-source-locations/quickstart.md
+++ b/specs/001-source-locations/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: Validating U1 Source Locations
+
+**Feature**: specs/001-source-locations/spec.md
+
+## Prerequisites
+
+- Linux with cmake ≥ 3.16, a C++17 compiler, and `llvm-18-dev` (for the
+  LLVM-build gate; the parse-only gate needs no LLVM).
+- Repo root, branch `epic/blang-ast/u1-source-locations`.
+
+## Build (both modes)
+
+```bash
+cmake -S . -B build -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm
+cmake --build build -j"$(nproc)"
+
+cmake -S . -B build-parse -DBLANG_ENABLE_LLVM=OFF
+cmake --build build-parse -j"$(nproc)"
+```
+
+## Validate the feature
+
+```bash
+# 1. Golden-location diffs (the unit's core acceptance; see contracts/)
+build/qcc --dump-locations test_files/pass/func_simple.b \
+  | diff - test_files/golden/func_simple.locations
+build/qcc --dump-locations test_files/pass/match_basic.b \
+  | diff - test_files/golden/match_basic.locations
+
+# 2. No zero line/col anywhere in either dump
+for f in func_simple match_basic; do
+  build/qcc --dump-locations test_files/pass/$f.b \
+    | grep -E ':0:[0-9]+ |:[0-9]+:0 ' && echo "FAIL: unset location" && exit 1
+done; echo OK
+
+# 3. Determinism: two runs, identical bytes
+diff <(build/qcc --dump-locations test_files/pass/match_basic.b) \
+     <(build/qcc --dump-locations test_files/pass/match_basic.b)
+
+# 4. Parse-only build produces the identical dump (no LLVM dependency)
+diff <(build/qcc --dump-locations test_files/pass/match_basic.b) \
+     <(build-parse/qcc --dump-locations test_files/pass/match_basic.b)
+
+# 5. Token-accurate error locations (behavioral spot check): a fail-suite
+#    file still fails, and the reported line matches the offending token
+build/qcc test_files/fail/missing_brace.b; echo "exit=$? (expect non-zero)"
+```
+
+## Regression gates (must all stay green — constitution Principle II)
+
+```bash
+# Gate A — LLVM build, full suites
+./run_tests.sh && ./test_codegen.sh
+
+# Gate B — parse-only build
+BUILD_DIR=build-parse ./run_tests.sh
+```
+
+## Expected outcomes
+
+- Both golden diffs and both determinism/parity diffs: empty output, exit 0.
+- Zero-location grep: no matches.
+- Suites: same pass counts as launch baseline (162 parse tests LLVM /
+  154 parse-only; 63 codegen E2E).
+- Hand spot-check (SC-005): open `test_files/pass/match_basic.b`, count by
+  eye the line/column of ≥ 5 constructs of different node kinds, and
+  confirm the dump agrees.

--- a/specs/001-source-locations/research.md
+++ b/specs/001-source-locations/research.md
@@ -38,7 +38,7 @@ verified by reading the sources on branch `epic/blang-ast/u1-source-locations`
   for definitions (FunctionDefinition, StructDefinition, EnumDefinition,
   ProtocolDefinition, VariableDefinition); `Type : virtual public RefCount`
   (Type.h:39). There is no single common AST base below `RefCount`.
-- ~413 `COMPILE_ERROR`/`throw CompileError` sites across the parser.
+- ~215 `COMPILE_ERROR`/`throw CompileError` sites across the parser.
 - `BmodEmitter` (BmodEmitter.h) is the house precedent for a standalone
   AST-walking emitter class separate from the nodes.
 - `qcc.cpp` flag parsing is a simple `argv` string-compare chain
@@ -143,11 +143,11 @@ reference may remain only if something else needs it — target: remove).
 The C++ `__FILE__`/`__LINE__` members stay (U2 will expose them only
 under `--debug-compiler`). `getMessage()` keeps its current shape but
 reads the line from the stored location — token-accurate, no live-lexer
-dependency (spec FR-005). All ~413 throw sites keep the same macro
+dependency (spec FR-005). All ~215 throw sites keep the same macro
 invocation; only the macro body changes.
 
 **Rationale**: Snapshot-at-throw is exactly what "stop leaning on the
-live lexer" means; keeping the macro signature makes the 413 sites a
+live lexer" means; keeping the macro signature makes the 215 sites a
 zero-touch migration.
 
 **Alternatives considered**: Rewriting each site to pass explicit

--- a/specs/001-source-locations/research.md
+++ b/specs/001-source-locations/research.md
@@ -1,0 +1,232 @@
+# Research: Source Locations End to End (U1)
+
+**Feature**: specs/001-source-locations/spec.md
+**Date**: 2026-07-13
+
+All unknowns from the Technical Context are resolved below. Code facts were
+verified by reading the sources on branch `epic/blang-ast/u1-source-locations`
+(base: master @ 1269b95).
+
+## Verified code facts (inputs to the decisions)
+
+- `Lexer` (FileLexer.h/.cpp) pre-tokenizes into `mSymbolList`
+  (`SymbolInfo {symbol, symbolText}`) and replays it via `mCurrentPos`;
+  the parser backtracks with `getCurrentPos()`/`setCurrentPos()`
+  (FileLexer.cpp:292-304). `SymbolInfo` stores **no position**, so
+  `getLineNumber()` returns the file read-ahead line, which is wrong for any
+  replayed token.
+- `charPos` is initialized once (FileLexer.cpp:11) and never incremented;
+  `getLinePosition()` is dead.
+- All character consumption funnels through `LexerReader::popChar()` /
+  `popChar(int)` (LexerReader.cpp) — including keyword `match()`, symbol,
+  string/char/number constants, comments, and whitespace skipping.
+- `lineno` is incremented in exactly two places: whitespace `'\n'`
+  (FileLexer.cpp:573) and `handleComment` (FileLexer.cpp:255). Newlines
+  inside multi-line string/char constants do NOT increment it
+  (FileLexer.cpp:103,175) — line numbers drift after such tokens today.
+- The filename is used to open `LexerReader::mFile` (LexerReader.cpp:3-5)
+  and then discarded; neither `Lexer` nor `LexerReader` retains it.
+- `getSymbolInternal()` unconditionally prints `Symbol ...` to **stdout**
+  for every token (FileLexer.cpp:321-324); `qcc.cpp` prints `import ...`,
+  AST dumps (`cout << *def`, qcc.cpp:282), and `Completed parse`
+  (qcc.cpp:681) to stdout.
+- `CompileError` (CompilerHelpers.h) holds `Lexer&` + C++ `__FILE__`/
+  `__LINE__`; `getMessage()` (qcc.cpp:27-33) reads
+  `mLexer.getLineNumber()` at *report* time.
+- AST bases: `Statement : virtual public RefCount` (Type.h:28) for all
+  statements/expressions; `Symbol : virtual public RefCount` (Type.h:81)
+  for definitions (FunctionDefinition, StructDefinition, EnumDefinition,
+  ProtocolDefinition, VariableDefinition); `Type : virtual public RefCount`
+  (Type.h:39). There is no single common AST base below `RefCount`.
+- ~413 `COMPILE_ERROR`/`throw CompileError` sites across the parser.
+- `BmodEmitter` (BmodEmitter.h) is the house precedent for a standalone
+  AST-walking emitter class separate from the nodes.
+- `qcc.cpp` flag parsing is a simple `argv` string-compare chain
+  (qcc.cpp:438-470) — trivially extensible.
+
+## R1 — Where per-token positions live
+
+**Decision**: Extend `SymbolInfo` to `{symbol, symbolText, line, col}`.
+Token positions are captured when the token is first scanned from the file
+and stored in the symbol list; replay (`getSymbolInternal` list branch) and
+backtracking (`setCurrentPos`) therefore return exact positions for free.
+`Lexer` gains accessors that report the position of the token at the
+current parse position (the token just returned / about to be returned),
+plus the filename.
+
+**Rationale**: The symbol list is the single point every token flows
+through, in both scan and replay paths; storing position there is the only
+design in which backtracking cannot desynchronize positions (spec FR-001,
+User Story 2).
+
+**Alternatives considered**: (a) Recompute positions on demand by re-reading
+the file — O(n) per query, fragile with the streaming reader. (b) Keep a
+parallel position vector — same content, worse locality/invariants than
+widening `SymbolInfo`.
+
+## R2 — Where line/column counting happens
+
+**Decision**: Count in `LexerReader`: `popChar()` advances `col` by 1 per
+character consumed; on consuming `'\n'` it increments `line` and resets
+`col` to 1. `LexerReader` also retains the filename. `Lexer` snapshots
+`reader.line/col` immediately before token recognition begins (after
+whitespace/comment skipping, at the first character of the token) and
+stores that snapshot into the new `SymbolInfo` fields.
+
+**Rationale**: Every consumption path (keywords, symbols, string/char/
+number constants, comments, whitespace) already funnels through
+`popChar`; counting there covers multi-line strings and block comments
+automatically — fixing the existing drift where newlines inside string
+constants are never counted (spec Edge Case "multi-line tokens").
+Snapshot-at-token-start gives the token's first character, which is the
+location contract for nodes (spec Assumption "node location = first
+token").
+
+**Alternatives considered**: Keep counting in `Lexer` at each site that
+inspects `'\n'` — misses multi-line constants (the existing bug) and must
+be replicated in ~6 scan helpers; rejected as error-prone.
+
+**Convention locked**: line and column are 1-based; every consumed
+character (including tab and `'\r'`) advances the column by exactly 1.
+Golden files are the arbiter of this convention (spec Assumptions).
+
+## R3 — SourceLocation type and which AST bases carry it
+
+**Decision**: A new lightweight header `SourceLocation.h` defines
+`struct SourceLocation { std::string file; uint32_t line = 0; uint32_t
+col = 0; }` (value type, no RefCount). `Statement` (Type.h:28) and
+`Symbol` (Type.h:81) each gain a protected `SourceLocation mLocation` with
+public `setLocation(...)`/`getLocation()`. `Type` nodes also gain it (types
+are parsed constructs and later units will diagnose on them). Every
+`Parse` factory stamps the node with the lexer's current token location
+captured **at entry**, before consuming the construct's first token's
+successors.
+
+**Rationale**: There is no common AST base below `RefCount`, and
+introducing one would restructure the hierarchy — forbidden by the seam
+constraint (parser shape stays). Duplicating one small member across the
+two (plus `Type`) bases is the minimal-footprint way to satisfy "every
+node type in Expression.h and Type.h" (spec FR-003).
+
+**Alternatives considered**: (a) New common base `AstNode` between
+RefCount and Statement/Symbol — restructures the hierarchy, violates the
+design.md seam. (b) Put location in `RefCount` — pollutes a generic
+utility class used outside the AST. (c) Side-table keyed by node pointer —
+lifetime hazards with SmartPtr, and downstream units want `node->getLocation()`
+directly.
+
+## R4 — How `Parse` methods capture the location
+
+**Decision**: Each `Parse` factory captures
+`SourceLocation loc = l.getTokenLocation();` (position of the *next* token
+to be consumed) as its first action, and calls `node->setLocation(loc)` on
+the node(s) it constructs. Sub-expressions parsed by helper routines stamp
+their own nodes the same way; nodes synthesized during desugaring inherit
+the location of the construct that produced them (spec FR-004). Binary
+operation nodes take the location of their first operand's first token
+(spec Assumption).
+
+**Rationale**: Capture-at-entry is mechanical, uniform across ~30 Q*.cpp
+files, and immune to how much lookahead/backtracking the method performs
+afterward — the value is already snapshotted.
+
+**Alternatives considered**: Stamp in node constructors by passing
+`Lexer&` down — touches every constructor signature (larger, riskier diff)
+for no accuracy gain.
+
+## R5 — `CompileError` carries a location
+
+**Decision**: `CompileError` gains a `SourceLocation mLocation` populated
+by the `COMPILE_ERROR(l, message)` macro via `l.getTokenLocation()` at
+throw time; the `Lexer&` member is dropped from the reporting path (the
+reference may remain only if something else needs it — target: remove).
+The C++ `__FILE__`/`__LINE__` members stay (U2 will expose them only
+under `--debug-compiler`). `getMessage()` keeps its current shape but
+reads the line from the stored location — token-accurate, no live-lexer
+dependency (spec FR-005). All ~413 throw sites keep the same macro
+invocation; only the macro body changes.
+
+**Rationale**: Snapshot-at-throw is exactly what "stop leaning on the
+live lexer" means; keeping the macro signature makes the 413 sites a
+zero-touch migration.
+
+**Alternatives considered**: Rewriting each site to pass explicit
+locations — enormous diff, U1 gains nothing; specific sites can be
+refined when U2 reworks messages.
+
+## R6 — `--dump-locations` traversal and NodeKind naming
+
+**Decision**: New `LocationDumper` class (LocationDumper.h/.cpp) following
+the `BmodEmitter` precedent: a standalone walker, `dynamic_cast`-dispatched
+like CodeGen, that visits the parsed module(s) in **pre-order** (parent
+before children, children in source order) and prints
+`<file>:<line>:<col> <NodeKind>` per node to stdout. `<NodeKind>` is the
+node's C++ class name obtained from `typeid` demangled via
+`abi::__cxa_demangle` with the `QLang::` prefix stripped.
+
+**Rationale**: A standalone walker matches house precedent and keeps the
+dump out of the node classes. `typeid` naming means *every* node prints a
+correct, stable kind name even for a node class the walker's child
+recursion doesn't know yet — coverage failures degrade to missing
+children, never to wrong names. Names are stable on the Itanium C++ ABI
+(GCC/Clang on Linux/macOS — the project's platforms), and the golden
+files pin them.
+
+**Alternatives considered**: (a) `virtual getNodeKind()` on every node
+class — ~50 mechanical overrides, and a missed override silently reports
+the base class name; rejected as more edits for less safety. (b) Reuse
+`operator<<` AST printing — not one-line-per-node, not location-bearing.
+
+## R7 — Keeping the dump byte-clean (golden diffs) without doing U2's job
+
+**Decision**: `--dump-locations` implies parse-only and produces *only*
+dump lines on stdout. To achieve that in U1: the lexer's per-token echo
+(FileLexer.cpp:321-324) becomes conditional on a trace flag
+(`Lexer::setTraceEnabled(bool)`, default **unchanged** = on), and qcc's
+informational prints (`import ...`, AST dump, `Completed parse`) are
+skipped when `--dump-locations` is active. Default-mode output is
+otherwise untouched; U2 owns quiet-by-default and `-v` gating globally.
+
+**Rationale**: The unit's own done-when ("prints one `<file>:<line>:<col>
+<NodeKind>` line per AST node", golden `diff` exits 0) is unmeetable if
+token spew interleaves with dump lines on stdout. This is the minimal
+carve-out; flipping defaults stays in U2 (spec Out of Scope). Existing
+tests assert exit codes, not output, so no suite impact either way.
+
+**Alternatives considered**: (a) Bake the spew into the golden files —
+locks garbage into goldens and guarantees a golden churn in U2. (b) Print
+the dump to a file instead of stdout — contradicts the epic workplan's
+literal done-when command (`qcc --dump-locations file | diff - golden`).
+
+## R8 — Golden file creation and verification
+
+**Decision**: Golden files `test_files/golden/func_simple.locations` and
+`test_files/golden/match_basic.locations` are generated by the new flag,
+then **hand-verified once** — every line's line/col checked by eye against
+the `.b` source (per spec SC-005, ≥ 5 node kinds spot-checked; in practice
+all lines of both files) — and committed. `run_tests.sh` is NOT modified
+in U1 (harness changes are U2); the golden diffs run as the unit's gate
+commands and as future units' regression locks.
+
+**Rationale**: Golden-generation-then-verify is the only honest way to
+bootstrap; the hand-verification requirement guards against locking in a
+wrong convention. Keeping run_tests.sh untouched keeps U1's diff minimal
+and leaves harness design decisions consolidated in U2.
+
+**Alternatives considered**: Wiring the golden diff into run_tests.sh now —
+overlaps U2's harness redesign; the evaluation.md per-unit gate already
+runs the diffs explicitly.
+
+## Risks carried into implementation
+
+- **Line-number drift fix changes error text**: files with multi-line
+  strings/comments now report *more accurate* line numbers in parse
+  errors. `fail/` tests assert exit codes only, so suites stay green.
+- **Peek vs. get position semantics**: `peekSymbol()` pre-reads a token
+  (`mLastSym`); `getTokenLocation()` must be defined against the token at
+  `mCurrentPos` (the next token the parser will consume), and the
+  implementation must keep peek/get consistent. Covered by golden files
+  containing backtrack-heavy constructs (match arms, statement dispatch).
+- **`--combine`/multi-file**: each Lexer instance carries its own
+  filename; nodes from different files report their own file (spec Edge
+  Case). Dump emits per input file in command-line order.

--- a/specs/001-source-locations/spec.md
+++ b/specs/001-source-locations/spec.md
@@ -1,0 +1,257 @@
+# Feature Specification: Source Locations End to End (U1)
+
+**Feature Branch**: `epic/blang-ast/u1-source-locations`
+
+**Created**: 2026-07-13
+
+**Status**: Draft
+
+**Epic**: blang-ast (docs/epics/blang-ast/) — Unit U1, covers **REQ-001**
+
+**Input**: User description: "U1 — Source locations end to end. Every AST node
+carries a source location (file, line, column). Store the source filename in
+the lexer; make column tracking real (charPos is dead); add a SourceLocation
+{file, line, col} to the AST base captured at parse time in every Parse
+method; CompileError carries a SourceLocation instead of leaning on the live
+lexer. Deliver a --dump-locations flag with two committed golden files."
+
+## Context
+
+BLang's AST carries no source positions today. The lexer tracks a line
+counter only; `charPos` is initialized once and never incremented; the source
+filename is discarded after the file is opened; `CompileError` formats the
+compiler's own C++ `__FILE__:__LINE__` and reads the line number from the
+*live lexer* at report time. Additionally, the lexer pre-tokenizes into a
+symbol list that the parser replays with backtracking (`getCurrentPos`/
+`setCurrentPos`), so the lexer's line counter reflects the file read-ahead
+position — not the token the parser is actually looking at. Error line
+numbers are therefore approximate today and become wrong whenever the parser
+has backtracked.
+
+This unit is the foundation of the blang-ast epic: U2 (diagnostics engine)
+and U3+ (semantic analysis) consume the locations introduced here. Nothing in
+this unit changes what programs are accepted or rejected.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Every AST node knows where it came from (Priority: P1)
+
+As a compiler developer (and, downstream, as a BLang user receiving
+diagnostics), every node the parser builds must record the source file, line,
+and column of the token that begins the construct, so that any later phase
+can point at the user's code exactly.
+
+**Why this priority**: This is REQ-001 itself and the epic's foundation;
+every diagnostic in U2–U8 depends on it.
+
+**Independent Test**: Parse a known file with `--dump-locations` and compare
+against a committed golden file; verify no node reports line 0 or column 0.
+
+**Acceptance Scenarios**:
+
+1. **Given** `test_files/pass/func_simple.b`, **When**
+   `build/qcc --dump-locations test_files/pass/func_simple.b` is run,
+   **Then** it prints one `<file>:<line>:<col> <NodeKind>` line per AST node
+   in a deterministic order and the output is byte-identical to
+   `test_files/golden/func_simple.locations` (diff exits 0).
+2. **Given** `test_files/pass/match_basic.b`, **When** the same command is
+   run against `test_files/golden/match_basic.locations`, **Then** diff
+   exits 0.
+3. **Given** either dump, **When** any line is inspected, **Then** its line
+   number ≥ 1 and column number ≥ 1 (no unset/zero locations).
+4. **Given** a construct that begins mid-line (e.g., an initializer
+   expression after `=`), **When** its node is dumped, **Then** the column
+   points at that construct's first token, not at column 1.
+
+---
+
+### User Story 2 - Locations are accurate despite parser backtracking (Priority: P2)
+
+The parser speculatively parses and rewinds (symbol-list replay with
+`getCurrentPos`/`setCurrentPos`). Locations captured on nodes and errors must
+correspond to the token at the parser's *current* position, not to how far
+the lexer has read ahead in the file.
+
+**Why this priority**: Without this, locations exist but lie — worse than
+none. This is the main correctness risk in the unit.
+
+**Independent Test**: Golden files include constructs whose parse path
+involves backtracking (e.g., statement dispatch in `match_basic.b`);
+locations in the goldens are hand-verified against the source once, then
+locked.
+
+**Acceptance Scenarios**:
+
+1. **Given** a construct reached only after the parser rewinds, **When** its
+   node's location is dumped, **Then** the line/column match the construct's
+   first token as counted by eye in the source file.
+2. **Given** a parse error thrown after backtracking, **When** the error is
+   reported, **Then** the line number reported corresponds to the offending
+   token (token-accurate), not the lexer's read-ahead position.
+
+---
+
+### User Story 3 - Parse errors carry a location value (Priority: P3)
+
+`CompileError` carries a `SourceLocation` (file, line, column) captured at
+throw time, so error reporting no longer needs to interrogate the live lexer
+and so U2 can format `<file>:<line>:<col>: error: <message>` without further
+plumbing.
+
+**Why this priority**: Plumbing for U2; user-visible formatting itself is
+U2's scope, not U1's.
+
+**Acceptance Scenarios**:
+
+1. **Given** a file that fails to parse, **When** the error is reported,
+   **Then** the reported line number is the offending token's line (the
+   existing message shape may remain; its line number becomes
+   token-accurate).
+2. **Given** all 41 `test_files/fail/` tests, **When** the suite runs,
+   **Then** each still exits non-zero (rejection behavior unchanged).
+
+---
+
+### Edge Cases
+
+- **First token of the file**: location must be `1:1` for a construct
+  starting at the top of the file.
+- **Tabs in source**: a tab advances the column by exactly 1 (columns count
+  characters, not visual width). Golden files lock this convention.
+- **Multi-line constructs** (a function spanning many lines): the node's
+  location is its *first* token; child nodes carry their own locations.
+- **Multi-line tokens** (block comments, multi-line strings): tokens after
+  the comment/string must have correct line AND column (column resets per
+  line inside the token scan).
+- **Error at end of file** (e.g., missing `}`): the error location must be a
+  valid position at/near EOF, never 0:0.
+- **Multiple input files** on one command line (including `--combine` and
+  `.bmod` consumption): each node's location names the file it was actually
+  parsed from.
+- **Nodes synthesized without a fresh token** (e.g., implicit/desugared
+  nodes): they must inherit a real location from the construct that produced
+  them — never 0:0.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The lexer MUST track, for every token it produces, the source
+  file name, 1-based line number, and 1-based column number of the token's
+  first character, and MUST report these accurately for the token at the
+  parser's current position even after position save/restore (backtracking).
+- **FR-002**: The lexer MUST expose the current file/line/column to the
+  parser at any point during parsing (a query answering "where is the token
+  I'm about to consume / just consumed").
+- **FR-003**: Every AST node (every class deriving from the statement/
+  expression/definition base) MUST carry a `SourceLocation` value —
+  file, line, column — populated at parse time in every `Parse` factory
+  method, set to the location of the construct's first token.
+- **FR-004**: No parsed AST node may carry an unset location: line ≥ 1 and
+  column ≥ 1 for every node reachable from a successfully parsed module.
+  Synthesized/desugared nodes inherit the location of their source
+  construct.
+- **FR-005**: `CompileError` MUST carry a `SourceLocation` captured at throw
+  time. Reporting a `CompileError` MUST NOT require access to the live
+  lexer. The compiler's own C++ `__FILE__`/`__LINE__` may still be captured
+  internally but the user-visible message format otherwise stays as-is
+  (reformatting is U2's scope); the line number it shows becomes
+  token-accurate.
+- **FR-006**: `qcc` MUST gain a `--dump-locations` flag that, after a
+  successful parse, prints to stdout exactly one line per AST node in the
+  form `<file>:<line>:<col> <NodeKind>`, in a deterministic order (a fixed
+  traversal of the AST, stable across runs and rebuilds), then exits 0
+  without generating IR. `<file>` is the path as given on the command line;
+  `<NodeKind>` is a stable, human-readable node-class name.
+- **FR-007**: Two golden files MUST be committed —
+  `test_files/golden/func_simple.locations` and
+  `test_files/golden/match_basic.locations` — such that
+  `build/qcc --dump-locations test_files/pass/func_simple.b | diff - test_files/golden/func_simple.locations`
+  and the `match_basic` equivalent both exit 0.
+- **FR-008**: The parser's external shape MUST NOT change: `Parse(Lexer&,
+  Scope*)` factory signatures may gain location capture internally but the
+  recursive-descent structure, `SmartPtr` ownership, and `QLang` namespace
+  remain (design.md seam constraint). Accepted/rejected program behavior is
+  unchanged.
+- **FR-009**: The feature MUST work identically in both build modes (LLVM
+  and parse-only); `--dump-locations` has no LLVM dependency.
+- **FR-010**: All existing suites MUST remain green: `./run_tests.sh` and
+  `./test_codegen.sh` in the LLVM build; `BUILD_DIR=build-parse
+  ./run_tests.sh` in the parse-only build.
+
+### Key Entities
+
+- **SourceLocation**: value type of {file, line, column}. File identifies
+  the source file the token came from (as named on the command line); line
+  and column are 1-based positions of a token's first character.
+- **Token position record**: per-token file/line/column stored with each
+  tokenized symbol so replay/backtracking returns correct positions.
+- **AST node**: any parser-built object; now carries exactly one
+  SourceLocation (its first token's).
+- **CompileError**: parse-failure carrier; now holds a SourceLocation
+  snapshot taken when thrown.
+- **Location dump**: deterministic text rendering of the AST's locations,
+  one node per line, used for golden-file regression locking.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Both golden-file diffs exit 0 on a clean build:
+  `build/qcc --dump-locations test_files/pass/func_simple.b | diff - test_files/golden/func_simple.locations`
+  and the `match_basic` equivalent.
+- **SC-002**: Zero nodes in either dump report line 0 or column 0
+  (mechanically checkable: `grep -E ':0:|:0 ' <dump>` finds nothing).
+- **SC-003**: Full suites green in both build modes: `./run_tests.sh` (162
+  parse tests) and `./test_codegen.sh` (63 E2E tests) with the LLVM build;
+  `BUILD_DIR=build-parse ./run_tests.sh` with the parse-only build — same
+  pass counts as the launch baseline.
+- **SC-004**: Location dump output is identical across two consecutive runs
+  of the same binary on the same input (determinism).
+- **SC-005**: Every AST node class in the parser's class hierarchy exposes a
+  location; a spot-check of ≥ 5 node kinds across both golden files shows
+  line AND column matching a by-eye count of the source.
+
+## Assumptions
+
+- **Column convention**: columns are 1-based and count characters from the
+  start of the line; a tab counts as one column. The golden files lock this
+  convention; changing it later is a golden-file update, not a breaking
+  change.
+- **Node location = first token**: a node's location is the position of the
+  first token of its construct (e.g., `if` keyword for an IfStatement, the
+  left operand's first token for a binary operation). Golden files lock the
+  per-node-kind outcome.
+- **Dump order**: "deterministic order" is a fixed pre-order (parent before
+  children, children in source order) traversal of the parsed module —
+  chosen because it is stable and human-checkable. The golden files are the
+  arbiter.
+- **Dump scope**: `--dump-locations` dumps the AST of each `.b` input file
+  in command-line order. The golden tests exercise single-file invocations;
+  multi-file behavior just follows the same per-file dump rule.
+- **`<NodeKind>` naming**: the existing AST class names (e.g.,
+  `FunctionDefinition`, `IfStatement`, `ConstInteger`) are the stable node
+  kind names.
+- **User-visible error format is NOT re-specified here**: U2 owns
+  `<file>:<line>:<col>: error: <message>`. U1 only guarantees the location
+  *data* exists and is accurate; the existing error message shape may
+  persist through U1 as long as fail-suite behavior (non-zero exit) is
+  unchanged.
+- **Existing `fail/` tests assert exit codes only** (expected-message mode
+  arrives in U2), so a token-accurate line number appearing in an error
+  message cannot break the suite.
+- **Documentation**: `CLAUDE.md` CLI-features text gains `--dump-locations`
+  (constitution Principle I); `docs/language_design.md` is untouched (no
+  language semantics change).
+- **Golden files are hand-verified once** at creation (columns counted by
+  eye against the source) and then serve as regression locks.
+
+## Out of Scope
+
+- Reformatting user-visible error messages (`<file>:<line>:<col>: error:`)
+  — U2.
+- The DiagnosticEngine, error-message content, quiet-by-default output — U2.
+- Any semantic checking — U3+.
+- End location / span tracking (only the start location is required).
+- Locations for the legacy Bison/Flex path (`parser.yy`, `lexer.l`,
+  `parse_helpers.cpp`) — dead code per the epic's non-goals.

--- a/specs/001-source-locations/tasks.md
+++ b/specs/001-source-locations/tasks.md
@@ -148,7 +148,7 @@ reported lines token-accurate.
       message)` macro captures `(l).getTokenLocation()` at throw; remove
       the `Lexer&` member from the reporting path (keep C++
       `__FILE__`/`__LINE__` fields for U2's `--debug-compiler`). All
-      ~413 call sites compile unchanged. (research R5, spec FR-005)
+      ~215 call sites compile unchanged. (research R5, spec FR-005)
 - [ ] T016 [US3] `qcc.cpp:27-33`: `CompileError::getMessage()` reads the
       stored `mLocation` (token-accurate line) instead of
       `mLexer.getLineNumber()`; keep the existing message shape

--- a/specs/001-source-locations/tasks.md
+++ b/specs/001-source-locations/tasks.md
@@ -1,0 +1,220 @@
+# Tasks: Source Locations End to End (U1)
+
+**Input**: Design documents from `specs/001-source-locations/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md,
+contracts/dump-locations-cli.md, quickstart.md
+
+**Tests**: This unit's tests ARE the two committed golden-location files
+plus the regression gates (spec FR-007/FR-010); no new pass/fail/codegen
+tests are required because accepted/rejected behavior is unchanged
+(plan.md Constitution Check, Principle II).
+
+**Organization**: Grouped by the spec's user stories. US1 = nodes carry
+locations (+dump/goldens), US2 = backtracking accuracy, US3 =
+CompileError carries a location.
+
+## Format: `[ID] [P?] [Story] Description`
+
+## Phase 1: Setup
+
+- [ ] T001 Create `SourceLocation.h` at repo root: `struct SourceLocation
+      { std::string file; uint32_t line = 0; uint32_t col = 0; }` per
+      data-model.md; PascalCase header, tabs, no RefCount.
+- [ ] T002 Add `test_files/golden/` directory (empty placeholder is fine
+      until T017 commits goldens).
+
+## Phase 2: Foundational (blocking prerequisites)
+
+**Purpose**: accurate per-token positions in the lexer — every user story
+depends on this.
+
+**⚠️ CRITICAL**: no story work until this phase is complete.
+
+- [ ] T003 `FileLexer.h` + `LexerReader.cpp`: LexerReader retains
+      `mFileName` and counts `mLine` (starts 1, incremented when `popChar`
+      consumes `'\n'`) and `mCol` (starts 1, +1 per consumed char, reset
+      to 1 after newline); add getters. `popChar(int)` loops through the
+      counting path. (research R2)
+- [ ] T004 `FileLexer.h` + `FileLexer.cpp`: widen `SymbolInfo` to
+      `{symbol, symbolText, line, col}`; in `getSymbolFromFile()` snapshot
+      reader line/col at the start of token recognition (after
+      whitespace/comment skipping, before the first matching char is
+      consumed) and store the snapshot when pushing into `mSymbolList`
+      (`getSymbolInternal`). (research R1/R2 — note the whitespace loop
+      structure: the snapshot must be of the token's first character, so
+      capture at each loop iteration before attempting matches)
+- [ ] T005 `FileLexer.h` + `FileLexer.cpp`: add
+      `Lexer::getTokenLocation()` returning `SourceLocation{file, line,
+      col}` of the token at the current parse position (the next token
+      the parser will consume; consistent across `peekSymbol`/`getSymbol`
+      and correct after `setCurrentPos`); add `getFileName()`; make
+      `getLineNumber()`/`getLinePosition()` delegate to the current token
+      record. Wire the filename from `qcc.cpp` (which owns the path
+      string) into LexerReader/Lexer construction.
+- [ ] T006 `FileLexer.h` + `FileLexer.cpp`: add
+      `Lexer::setTraceEnabled(bool)` (default preserves today's output)
+      gating the per-token `std::cout` echo in `getSymbolInternal()`
+      (FileLexer.cpp:321-324). Default-mode output must be unchanged.
+      (research R7)
+
+**Checkpoint**: lexer unit-testable by hand — `getTokenLocation()` is
+accurate after backtracking.
+
+## Phase 3: User Story 1 — Every AST node knows where it came from (P1) 🎯 MVP
+
+**Goal**: SourceLocation on every parsed node; `--dump-locations`;
+committed goldens.
+
+**Independent Test**: golden diffs exit 0; zero `line 0`/`col 0` entries
+(quickstart.md steps 1–4).
+
+- [ ] T007 [US1] `Type.h`: include `SourceLocation.h`; add protected
+      `SourceLocation mLocation` + public `setLocation()`/`getLocation()`
+      to `Statement` (Type.h:28), `Symbol` (Type.h:81), and `Type`
+      (Type.h:39). House style: `m`-prefix, tabs. (research R3)
+- [ ] T008 [US1] Stamp locations in every `Parse` factory across the
+      parser: capture `SourceLocation loc = l.getTokenLocation();` at
+      entry and `setLocation(loc)` on every node constructed. Files:
+      QBlock.cpp, QBreakContinue.cpp, QEnumDefinition.cpp,
+      QExpression.cpp, QForInStatement.cpp, QFunctionDefinition.cpp,
+      QReturnStatement.cpp, QStatement.cpp, QStructDefinition.cpp,
+      QType.cpp, QVariableDefinition.cpp, QSpawnStatement.cpp,
+      QEventHandler.cpp, QTestBlock.cpp, QAssertStatement.cpp,
+      QQueryExpression.cpp, QLambdaExpression.cpp, QMatchExpression.cpp,
+      QFieldAccessExpression.cpp, QImplBlock.cpp (and any other Q*.cpp
+      with a Parse). Rules: node location = construct's first token;
+      binary-operation nodes take the first operand's first token;
+      desugared/synthesized nodes inherit the originating construct's
+      location — no node may keep line/col 0. (research R4, spec FR-003/004)
+- [ ] T009 [P] [US1] Create `LocationDumper.h`/`LocationDumper.cpp`
+      (BmodEmitter precedent, QLang namespace): pre-order walker over
+      parsed module(s) printing `<file>:<line>:<col> <NodeKind>` per node
+      to a `std::ostream`; children in source order; NodeKind =
+      `typeid`-demangled class name (`abi::__cxa_demangle`) with
+      `QLang::` stripped; `dynamic_cast` dispatch covering every node
+      class in Expression.h/Type.h (unknown nodes still print their kind,
+      recursion just stops). (research R6; contract
+      contracts/dump-locations-cli.md)
+- [ ] T010 [US1] `qcc.cpp`: add `--dump-locations` flag (argv chain at
+      qcc.cpp:438-470) + `--help` text; implies parse-only; suppresses
+      non-dump stdout for the run (call `setTraceEnabled(false)`, skip
+      `import ...`/AST dump/`Completed parse` prints); invoke
+      LocationDumper per input file in command-line order; exit 0 on
+      success. Works identically without LLVM (no `BLANG_HAS_LLVM`
+      guard). (research R7, spec FR-006/FR-009)
+- [ ] T011 [US1] `CMakeLists.txt`: add `LocationDumper.cpp` to the `qcc`
+      target sources (both LLVM and non-LLVM configurations).
+- [ ] T012 [US1] Generate the two dumps, hand-verify EVERY line's
+      line/col by eye against `test_files/pass/func_simple.b` and
+      `test_files/pass/match_basic.b` (≥ 5 distinct node kinds — spec
+      SC-005), then commit `test_files/golden/func_simple.locations` and
+      `test_files/golden/match_basic.locations`. (research R8)
+
+**Checkpoint**: quickstart steps 1–4 pass (golden diffs, zero-location
+grep, determinism, build-mode parity).
+
+## Phase 4: User Story 2 — Locations accurate despite backtracking (P2)
+
+**Goal**: prove replay/backtracking positions are exact.
+
+**Independent Test**: match_basic golden contains backtrack-heavy
+constructs whose hand-verified positions match.
+
+- [ ] T013 [US2] Verify by hand (and fix if wrong): positions of nodes
+      reached through parser rewind paths — statement dispatch
+      (QStatement.cpp backtracking, `setCurrentPos`) and match arms in
+      `test_files/pass/match_basic.b` — match the by-eye source count in
+      the committed golden. Any mismatch is a bug in T004/T005 snapshot
+      logic; fix there, regenerate goldens, re-verify. (spec US2)
+- [ ] T014 [US2] Confirm `getLineNumber()` (used by error reporting) is
+      token-accurate after backtracking: force a parse error after a
+      rewind (e.g., `test_files/fail/match_missing_brace.b`) and check
+      the reported line matches the offending token by eye. Record the
+      observation in the PR description.
+
+**Checkpoint**: backtracking accuracy demonstrated and locked by goldens.
+
+## Phase 5: User Story 3 — Parse errors carry a location value (P3)
+
+**Goal**: `CompileError` snapshots location at throw; reporting stops
+reading the live lexer.
+
+**Independent Test**: fail-suite behavior unchanged (41 non-zero exits);
+reported lines token-accurate.
+
+- [ ] T015 [US3] `CompilerHelpers.h`: `CompileError` gains
+      `SourceLocation mLocation` + `getLocation()`; `COMPILE_ERROR(l,
+      message)` macro captures `(l).getTokenLocation()` at throw; remove
+      the `Lexer&` member from the reporting path (keep C++
+      `__FILE__`/`__LINE__` fields for U2's `--debug-compiler`). All
+      ~413 call sites compile unchanged. (research R5, spec FR-005)
+- [ ] T016 [US3] `qcc.cpp:27-33`: `CompileError::getMessage()` reads the
+      stored `mLocation` (token-accurate line) instead of
+      `mLexer.getLineNumber()`; keep the existing message shape
+      (reformatting is U2). Verify a few `fail/` fixtures by eye.
+
+**Checkpoint**: all three stories complete.
+
+## Phase 6: Polish & Gates
+
+- [ ] T017 [P] Update `CLAUDE.md`: add `--dump-locations` to the qcc CLI
+      features paragraph; note per-token location tracking + golden files
+      in the testing section. (constitution Principle I)
+- [ ] T018 Self-review the diff for house style (tabs, Allman,
+      `m`-prefix, spaces inside parens) and for accidental behavior
+      changes (default-mode stdout must be unchanged — research R7).
+- [ ] T019 Run the per-unit gates (evaluation.md) and fix failures:
+      ```bash
+      # Gate A — LLVM build; full suites
+      cmake -S . -B build -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm
+      cmake --build build -j"$(nproc)"
+      ./run_tests.sh
+      ./test_codegen.sh
+
+      # Gate B — parse-only build; parse suite
+      cmake -S . -B build-parse -DBLANG_ENABLE_LLVM=OFF
+      cmake --build build-parse -j"$(nproc)"
+      BUILD_DIR=build-parse ./run_tests.sh
+      ```
+- [ ] T020 Run the U1-specific checks (evaluation.md §Unit-specific
+      checks) and fix failures:
+      ```bash
+      ./build/qcc --dump-locations test_files/pass/func_simple.b \
+        | diff - test_files/golden/func_simple.locations
+      ./build/qcc --dump-locations test_files/pass/match_basic.b \
+        | diff - test_files/golden/match_basic.locations
+      # zero-location check
+      for f in func_simple match_basic; do
+        ./build/qcc --dump-locations test_files/pass/$f.b \
+          | grep -E ':0:[0-9]+ |:[0-9]+:0 ' && exit 1; done; true
+      # determinism + build-mode parity
+      diff <(./build/qcc --dump-locations test_files/pass/match_basic.b) \
+           <(./build/qcc --dump-locations test_files/pass/match_basic.b)
+      diff <(./build/qcc --dump-locations test_files/pass/match_basic.b) \
+           <(./build-parse/qcc --dump-locations test_files/pass/match_basic.b)
+      ```
+
+## Dependencies & Execution Order
+
+- Phase 1 (T001–T002) → Phase 2 (T003–T006, strictly ordered T003→T004→
+  T005; T006 independent after T004) → user stories.
+- US1 (T007→T008; T009 [P] parallel with T007/T008; T010 after
+  T006+T009; T011 after T009; T012 last) — MVP.
+- US2 (T013–T014) needs US1's goldens; US3 (T015–T016) needs only
+  Phase 2 (can run parallel to US1/US2 — different files, except
+  qcc.cpp shared by T010/T016: serialize those two).
+- Phase 6 (T017–T020) after all stories; T017 [P] anytime after T010.
+
+## Parallel Opportunities
+
+- T009 (new files) alongside T007/T008.
+- T015/T016 (CompilerHelpers.h, qcc.cpp error path) alongside T013/T014.
+- T017 (CLAUDE.md) alongside any late task.
+
+## Implementation Strategy
+
+MVP = Phases 1–3 (US1): locations exist, dump works, goldens lock the
+convention. US2 is verification hardening on top; US3 is a small,
+mostly-independent slice. Gates (T019/T020) are the exit criteria the
+reviewer re-runs independently in Phase 4 of the unit lifecycle.

--- a/test_files/golden/func_simple.locations
+++ b/test_files/golden/func_simple.locations
@@ -1,0 +1,10 @@
+test_files/pass/func_simple.b:3:1 FunctionDefinition
+test_files/pass/func_simple.b:3:14 VariableDefinition
+test_files/pass/func_simple.b:4:1 Block
+test_files/pass/func_simple.b:5:2 ReturnStatement
+test_files/pass/func_simple.b:5:9 VariableExpression
+test_files/pass/func_simple.b:8:1 FunctionDefinition
+test_files/pass/func_simple.b:8:12 VariableDefinition
+test_files/pass/func_simple.b:9:1 Block
+test_files/pass/func_simple.b:10:2 ReturnStatement
+test_files/pass/func_simple.b:10:9 VariableExpression

--- a/test_files/golden/match_basic.locations
+++ b/test_files/golden/match_basic.locations
@@ -1,0 +1,17 @@
+test_files/pass/match_basic.b:1:1 FunctionDefinition
+test_files/pass/match_basic.b:1:14 VariableDefinition
+test_files/pass/match_basic.b:2:1 Block
+test_files/pass/match_basic.b:3:2 MatchExpression
+test_files/pass/match_basic.b:3:8 VariableExpression
+test_files/pass/match_basic.b:5:5 Block
+test_files/pass/match_basic.b:5:7 ReturnStatement
+test_files/pass/match_basic.b:5:14 ConstInteger
+test_files/pass/match_basic.b:6:5 Block
+test_files/pass/match_basic.b:6:7 ReturnStatement
+test_files/pass/match_basic.b:6:14 ConstInteger
+test_files/pass/match_basic.b:8:2 ReturnStatement
+test_files/pass/match_basic.b:8:9 VariableExpression
+test_files/pass/match_basic.b:11:1 FunctionDefinition
+test_files/pass/match_basic.b:12:1 Block
+test_files/pass/match_basic.b:13:2 ReturnStatement
+test_files/pass/match_basic.b:13:9 ConstInteger


### PR DESCRIPTION
## Unit U1 — Phase 1 (create spec) — DRAFT, no implementation yet

Epic: blang-ast (docs/epics/blang-ast/). Covers **REQ-001**: every AST node carries a source location (file, line, column).

### Speckit artifacts (specs/001-source-locations/)
- **spec.md** — 3 user stories (nodes carry locations / backtracking accuracy / CompileError location), FR-001..FR-010, measurable success criteria, recorded assumptions (column convention, node-location=first-token, pre-order dump, NodeKind naming), out-of-scope list (error formatting → U2).
- **research.md** — decisions R1–R8 grounded in verified code facts (per-token positions in the SymbolInfo replay list so backtracking can't desynchronize; counting in LexerReader::popChar fixing multi-line-token line drift; location on Statement/Symbol/Type bases; CompileError snapshot-at-throw; LocationDumper walker with typeid NodeKinds; minimal stdout suppression only in --dump-locations mode).
- **plan.md** — technical context, constitution check (v1.1.0, all principles PASS, no complexity exceptions), file-level structure.
- **data-model.md, contracts/dump-locations-cli.md, quickstart.md** — entity shapes, CLI + dump-line grammar contract, validation runbook.
- **tasks.md** — T001–T020, ending with Gate A/B and the U1 golden-diff checks from evaluation.md.

### Unit done-when (workplan.md U1)
`--dump-locations` flag; two committed goldens (`test_files/golden/{func_simple,match_basic}.locations`); both diffs exit 0; no node at line/col 0; all suites green in both build modes.

### For the spec audit (Phase 2)
Please apply the Spec audit rubric in docs/epics/blang-ast/evaluation.md. Implementation (Phase 3) will not begin until this spec is approved.