### PR TITLE
Set up Cursor Cloud dev environment for BLang

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+BLang is a single product: the C++17 compiler toolchain for the BLang language
+(driver `bcc` + parser/IR generator `qcc` + `libblang_*` runtime libs). There
+are no long-running services; "run the app" means compile a `.b` file to a
+native binary and execute it. Standard build/test/run commands live in
+`CLAUDE.md` (see "Build System", "Testing"); prefer those over duplicating here.
+
+Build with LLVM codegen (parse-only mode can't produce binaries):
+
+```bash
+mkdir -p build && cd build
+cmake .. -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm
+make -j$(nproc)
+```
+
+The update script only refreshes apt dependencies; it intentionally does NOT
+build. Run the `cmake`/`make` step yourself after startup (the `build/`
+directory is not persisted). Verify with `./run_tests.sh` (parse/fail suite,
+needs only `qcc`) and `./test_codegen.sh` (end-to-end qcc→llc→cc→run, needs the
+LLVM build). Compile+run a single program with
+`./build/bcc file.b -o out && ./out`.
+
+### Non-obvious gotchas
+
+- The `llvm-18` apt packages register clang as the default `cc`/`c++`
+  alternative, and clang-18 here targets the gcc-14 toolchain. `libstdc++-14-dev`
+  MUST be installed or every link fails with `cannot find -lstdc++` (this
+  affects both the CMake C++ compiler check and `bcc`'s link step, since `bcc`
+  bakes in whatever `cc` resolves to at configure time). It is included in the
+  update script.
+- `bcc` expects `qcc` in the same directory and needs `llc-18`/`llc` + `cc` on
+  PATH; tool paths (`cc`, `llc`, runtime lib paths, host arch) are baked into
+  `bcc` at CMake configure time, so re-run `cmake` if the toolchain moves.
+- LLVM 18, SQLite3, and libuv are present; libpq/PostgreSQL is absent so that DB
+  backend stays disabled (SQLite is the tested backend) — this is expected.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the BLang compiler development environment for Cursor Cloud agents, and documents non-obvious setup gotchas.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section (build/test/run pointers + toolchain gotchas).
- Registers a minimal, idempotent update script (apt dependency refresh) via the environment setup tool.

## Environment

- OS: Ubuntu 24.04, CMake 3.28, LLVM 18.1.3, SQLite3, libuv (libpq/Postgres intentionally absent → that DB backend stays disabled).
- Installed build deps: `cmake build-essential libuv1-dev pkg-config libsqlite3-dev llvm-18-dev libzstd-dev libstdc++-14-dev`.

## Key gotcha discovered

Installing `llvm-18` makes clang the default `cc`/`c++`, and clang-18 targets the gcc-14 toolchain, so `libstdc++-14-dev` is required or every link fails with `cannot find -lstdc++` (breaks both the CMake compiler check and `bcc`'s baked-in link step). Fixed by adding `libstdc++-14-dev` to the deps.

## Verification

- Build with LLVM: `cmake .. -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm && make -j$(nproc)` → all targets built.
- `./run_tests.sh` → 167/167 passed.
- `./test_codegen.sh` (end-to-end qcc→llc→cc→run) → 77/77 passed.
- Hello-world: `bcc hello.b -o hello && ./hello` compiled and ran correctly.

[blang_env_verification.log](https://cursor.com/agents/bc-834e351f-4902-4723-b214-b457e075c6c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblang_env_verification.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-834e351f-4902-4723-b214-b457e075c6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-834e351f-4902-4723-b214-b457e075c6c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

