### PR TITLE
U4: stdlib opaque API — KI-8/KI-10 renderer fixes + design audit

### DIFF
--- a/CGExpressions.cpp
+++ b/CGExpressions.cpp
@@ -955,27 +955,15 @@ llvm::Function *CodeGen::lookupToStringFn( StructDefinition *sd )
 	return nullptr;
 }
 
+// Only a VARIABLE or a FIELD ACCESS can be an interpolation part today — the
+// parser builds nothing else — and receiverStructDef handles both, including a
+// `self` base. Anything else is not a struct value.
 StructDefinition *CodeGen::structDefForInterpolationPart( Expression *part )
 {
-	std::string typeName;
-	if ( auto *ve = dynamic_cast<VariableExpression*>( part ) )
-	{
-		if ( ve->mVariable != nullptr && ve->mVariable->getVariableType() != nullptr )
-			typeName = ve->mVariable->getVariableType()->getName();
-	}
-	else if ( auto *fa = dynamic_cast<FieldAccessExpression*>( part ) )
-	{
-		Type *rt = fa->getResolvedType();
-		if ( rt != nullptr )
-			typeName = rt->getName();
-	}
-	if ( typeName.empty() )
+	if ( dynamic_cast<VariableExpression*>( part ) == nullptr &&
+		 dynamic_cast<FieldAccessExpression*>( part ) == nullptr )
 		return nullptr;
-
-	auto it = mStructDefMap.find( typeName );
-	if ( it == mStructDefMap.end() )
-		return nullptr;
-	return it->second;
+	return receiverStructDef( part );
 }
 
 // Render a struct value through the Printable protocol. `selfPtr` must already
@@ -1420,32 +1408,18 @@ void CodeGen::genPrintCall( CallExpression *call, bool appendNewline )
 				{
 					structTypeName = ve->mVariable->getVariableType()->getName();
 
-					// The implicit `self` parameter's declared type name is the
-					// literal "self", so it failed the struct test below and fell
+					// receiverStructDef, not a bare mStructDefMap lookup: the
+					// implicit `self` parameter's declared type name is the
+					// literal "self", so the name lookup missed and `self` fell
 					// through to the generic path — which handed a raw struct
 					// pointer to __blang_string_concat_many AS IF it were a
-					// BlangString. `println("{}", self)` therefore printed empty,
-					// a type confusion at the C boundary that rendered harmlessly
-					// by luck (known-issues KI-10). Resolve it to the enclosing
-					// struct, which mSelfStructMap already records.
-					if ( structTypeName == "self" )
+					// BlangString. `println("{}", self)` therefore printed
+					// empty, a type confusion at the C boundary that rendered
+					// harmlessly by luck (known-issues KI-10).
+					if ( StructDefinition *rsd = receiverStructDef( argExpr ) )
 					{
-						auto selfIt = mSelfStructMap.find( ve->mVariable );
-						if ( selfIt != mSelfStructMap.end() && selfIt->second != nullptr )
-							structTypeName = selfIt->second->getName();
-					}
-
-					if ( structTypeName != "string" && structTypeName != "cstring" &&
-						 structTypeName != "int" && structTypeName != "long" &&
-						 structTypeName != "short" && structTypeName != "char" &&
-						 structTypeName != "float" && structTypeName != "double" &&
-						 structTypeName != "bool" )
-					{
-						auto sIt = mStructDefMap.find( structTypeName );
-						if ( sIt != mStructDefMap.end() )
-						{
-							isStructArg = true;
-						}
+						structTypeName = rsd->getName();
+						isStructArg = true;
 					}
 				}
 			}

--- a/CGExpressions.cpp
+++ b/CGExpressions.cpp
@@ -918,6 +918,98 @@ llvm::AllocaInst *CodeGen::getExpressionAddress( Expression *expr )
 	return nullptr;
 }
 
+
+// The struct a string-interpolation part denotes, or nullptr when the part is
+// not a struct value. Used to route struct parts through Printable rather than
+// handing a struct pointer to the string runtime as if it were a BlangString.
+// The LLVM function implementing a struct's `to_string`. Prefers the emitted
+// symbol, then falls back to the method's entry in mFunctionMap — the symbol may
+// not exist yet when the CALLER is generated before the conformance impl block
+// that defines it (method emission follows source order).
+llvm::Function *CodeGen::lookupToStringFn( StructDefinition *sd )
+{
+	if ( sd == nullptr )
+		return nullptr;
+	if ( llvm::Function *fn = mModule->getFunction( sd->getName() + "_to_string" ) )
+		return fn;
+	for ( auto &msp : sd->mMethods )
+	{
+		FunctionDefinition *m = const_cast<FunctionDefinition*>(
+			(const FunctionDefinition*)msp );
+		if ( m == nullptr || m->getName() != "to_string" )
+			continue;
+		auto it = mFunctionMap.find( m );
+		if ( it != mFunctionMap.end() )
+			return it->second;
+
+		// The method is declared on the struct but its LLVM function has not
+		// been created yet: method bodies are generated in source order, so a
+		// caller earlier in the file reaches here before the conformance impl
+		// block that defines to_string. Forward-declare it; the definition lands
+		// later in this same module.
+		llvm::Type *ptrTy = llvm::PointerType::get( *mContext, 0 );
+		llvm::FunctionType *ft = llvm::FunctionType::get( ptrTy, { ptrTy }, false );
+		return llvm::Function::Create( ft, llvm::Function::ExternalLinkage,
+			sd->getName() + "_to_string", mModule.get() );
+	}
+	return nullptr;
+}
+
+StructDefinition *CodeGen::structDefForInterpolationPart( Expression *part )
+{
+	std::string typeName;
+	if ( auto *ve = dynamic_cast<VariableExpression*>( part ) )
+	{
+		if ( ve->mVariable != nullptr && ve->mVariable->getVariableType() != nullptr )
+			typeName = ve->mVariable->getVariableType()->getName();
+	}
+	else if ( auto *fa = dynamic_cast<FieldAccessExpression*>( part ) )
+	{
+		Type *rt = fa->getResolvedType();
+		if ( rt != nullptr )
+			typeName = rt->getName();
+	}
+	if ( typeName.empty() )
+		return nullptr;
+
+	auto it = mStructDefMap.find( typeName );
+	if ( it == mStructDefMap.end() )
+		return nullptr;
+	return it->second;
+}
+
+// Render a struct value through the Printable protocol. `selfPtr` must already
+// be the struct's self pointer (see genPrintCall for why that must come from the
+// variable's ADDRESS and not from a loaded value).
+llvm::Value *CodeGen::genPrintableToString( StructDefinition *sd, Expression *node,
+	llvm::Value *selfPtr )
+{
+	bool hasPrintable = false;
+	for ( const auto &proto : sd->getConformedProtocols() )
+		if ( proto == "Printable" )
+			hasPrintable = true;
+	if ( !hasPrintable && !sd->isFromInterface() )
+	{
+		for ( auto &m : sd->getMethods() )
+			if ( m->getName() == "to_string" )
+				hasPrintable = true;
+	}
+	if ( !hasPrintable )
+	{
+		reportError( node, "type '" + sd->getName() +
+			"' is not printable — implement the Printable protocol" );
+		return nullptr;
+	}
+
+	llvm::Function *toStrFn = lookupToStringFn( sd );
+	if ( toStrFn == nullptr )
+	{
+		reportError( node, "'" + sd->getName() + "_to_string' function not found" );
+		return nullptr;
+	}
+	return mBuilder->CreateCall( toStrFn, { selfPtr }, "interp.structstr" );
+}
+
 llvm::Value *CodeGen::genStringInterpolation( StringInterpolation *interp )
 {
 	if ( interp->mParts.empty() )
@@ -987,8 +1079,31 @@ llvm::Value *CodeGen::genStringInterpolation( StringInterpolation *interp )
 			}
 			else if ( val->getType()->isPointerTy() )
 			{
-				// Already a BlangString pointer — use directly (borrowed)
-				parts.push_back( val );
+				// A pointer here is EITHER a BlangString or a struct value —
+				// struct values are refcounted heap pointers too. Passing a
+				// struct straight through handed a non-BlangString to
+				// __blang_string_concat_many, which read a string header out of
+				// struct memory and rendered empty. Dispatch a struct through
+				// Printable instead, exactly as the `{}` placeholder path does.
+				StructDefinition *psd = structDefForInterpolationPart( part );
+				if ( psd != nullptr )
+				{
+					llvm::Value *strPart = genPrintableToString( psd, part, val );
+					if ( strPart == nullptr )
+						return nullptr;   // reportError already fired
+					// to_string returns a FRESH string (refcount 1) that nothing
+					// else owns — exactly like the intstr/fltstr/boolstr parts
+					// above — so it must be tracked or the interpolation leaks it.
+					// A BlangString part (the else branch) is BORROWED from the
+					// variable that holds it and must NOT be tracked.
+					trackTempString( strPart );
+					parts.push_back( strPart );
+				}
+				else
+				{
+					// Already a BlangString pointer — use directly (borrowed)
+					parts.push_back( val );
+				}
 			}
 		}
 	}
@@ -1304,6 +1419,22 @@ void CodeGen::genPrintCall( CallExpression *call, bool appendNewline )
 				if ( ve->mVariable && ve->mVariable->getVariableType() )
 				{
 					structTypeName = ve->mVariable->getVariableType()->getName();
+
+					// The implicit `self` parameter's declared type name is the
+					// literal "self", so it failed the struct test below and fell
+					// through to the generic path — which handed a raw struct
+					// pointer to __blang_string_concat_many AS IF it were a
+					// BlangString. `println("{}", self)` therefore printed empty,
+					// a type confusion at the C boundary that rendered harmlessly
+					// by luck (known-issues KI-10). Resolve it to the enclosing
+					// struct, which mSelfStructMap already records.
+					if ( structTypeName == "self" )
+					{
+						auto selfIt = mSelfStructMap.find( ve->mVariable );
+						if ( selfIt != mSelfStructMap.end() && selfIt->second != nullptr )
+							structTypeName = selfIt->second->getName();
+					}
+
 					if ( structTypeName != "string" && structTypeName != "cstring" &&
 						 structTypeName != "int" && structTypeName != "long" &&
 						 structTypeName != "short" && structTypeName != "char" &&
@@ -1377,7 +1508,7 @@ void CodeGen::genPrintCall( CallExpression *call, bool appendNewline )
 					return;
 				}
 				std::string fnName = structTypeName + "_to_string";
-				llvm::Function *toStrFn = mModule->getFunction( fnName );
+				llvm::Function *toStrFn = lookupToStringFn( sd );
 				if ( toStrFn )
 				{
 					// Obtain the receiver's self POINTER exactly as genMethodCall

--- a/CGStruct.cpp
+++ b/CGStruct.cpp
@@ -2126,6 +2126,43 @@ llvm::Value *CodeGen::genMethodCall( MethodCallExpression *expr )
 		}
 	}
 
+	// Field receiver: `h.inner.num()` and `self.inner.num()`. There was no branch
+	// for this at all, so structDef stayed null and genMethodCall returned
+	// nullptr — the call was DROPPED ON THE FLOOR with no diagnostic. A method
+	// whose body was `return self.inner.describe();` compiled to `ret ptr null`,
+	// and `println("{}", h.inner.num())` printed nothing. Composition — an object
+	// delegating to a field — is exactly the shape the opaque-accessor API
+	// pushes code towards, so this silently broke the idiom the epic promotes.
+	if ( structDef == nullptr )
+	{
+		if ( auto *fa = dynamic_cast<FieldAccessExpression*>( (Expression*)expr->mObject ) )
+		{
+			structDef = receiverStructDef( fa );
+			if ( structDef != nullptr )
+			{
+				structName = structDef->getName();
+
+				// A generic-instance field (Box<int> inner) dispatches to the
+				// monomorphized definition, mirroring the variable branch above.
+				Type *fieldType = getFieldType( fa );
+				if ( fieldType != nullptr && fieldType->getNumTypeParams() > 0 )
+				{
+					std::vector<SmartPtr<Type>> typeArgs;
+					for ( int i = 0; i < fieldType->getNumTypeParams(); i++ )
+						typeArgs.push_back( fieldType->getTypeParam( i ) );
+					string mangled = mangleGenericName(
+						fieldType->getName(), typeArgs );
+					auto defIt = mStructDefMap.find( mangled );
+					if ( defIt != mStructDefMap.end() && defIt->second != nullptr )
+					{
+						structDef = defIt->second;
+						structName = mangled;
+					}
+				}
+			}
+		}
+	}
+
 	// If structDef is still null, try to resolve from expression's return type
 	// (e.g., CallExpression receiver: info(path).exists())
 	if ( structDef == nullptr )

--- a/CGTypes.cpp
+++ b/CGTypes.cpp
@@ -1198,13 +1198,74 @@ std::string CodeGen::callReturnTypeName( CallExpression *call )
 	return resolvedTypeName( rt );
 }
 
+// The struct a RECEIVER expression denotes.
+//
+// The implicit `self` parameter's declared type name is the literal string
+// "self" — it does not name the enclosing struct — so every predicate that
+// resolves a receiver by looking its declared TYPE NAME up in mStructDefMap
+// silently misses on a self receiver and reports "not a struct". That single
+// fact produced two separate silent wrong answers (known-issues KI-10: `self`
+// as a print argument reached the string runtime as a raw struct pointer;
+// KI-8(b): `return self.describe()` was not recognised as a string return, so
+// the returned string was released before it was returned). Resolving it in one
+// place is what stops a third: mSelfStructMap holds the binding the parameter
+// actually carries, including the definition a monomorphized generic method is
+// being generated for.
+StructDefinition *CodeGen::receiverStructDef( Expression *obj )
+{
+	if ( obj == nullptr )
+		return nullptr;
+
+	std::string typeName;
+	if ( auto *ve = dynamic_cast<VariableExpression*>( obj ) )
+	{
+		auto selfIt = mSelfStructMap.find( ve->getVariable() );
+		if ( selfIt != mSelfStructMap.end() && selfIt->second != nullptr )
+			return selfIt->second;
+		if ( ve->getVariable() != nullptr &&
+			 ve->getVariable()->getVariableType() != nullptr )
+			typeName = ve->getVariable()->getVariableType()->getName();
+	}
+	else if ( auto *fa = dynamic_cast<FieldAccessExpression*>( obj ) )
+	{
+		// getFieldTypeName, not getResolvedType: Sema records only CONCRETE
+		// field types and leaves a SELF-based access unannotated, so
+		// `self.inner.describe()` and `"{self.inner}"` would otherwise resolve
+		// to nothing — the same self-shaped hole one level down.
+		typeName = getFieldTypeName( fa );
+	}
+	if ( typeName.empty() )
+	{
+		if ( Type *rt = obj->getResolvedType() )
+			typeName = rt->getName();
+	}
+	if ( typeName.empty() )
+		return nullptr;
+
+	// A generic parameter (T) resolves through the active monomorphization
+	// substitution before it can name a struct.
+	auto subIt = mTypeSubstitution.find( typeName );
+	if ( subIt != mTypeSubstitution.end() && subIt->second != nullptr )
+		typeName = subIt->second->getName();
+
+	// isUserStructType, not a bare map lookup: it is the single place that
+	// excludes the builtin names a struct map may also carry.
+	if ( !isUserStructType( typeName ) )
+		return nullptr;
+	auto it = mStructDefMap.find( typeName );
+	return ( it != mStructDefMap.end() ) ? it->second : nullptr;
+}
+
 std::string CodeGen::methodReturnTypeName( MethodCallExpression *mc )
 {
 	if ( mc == nullptr )
 		return "";
 
 	// The object's declared/resolved type carries the instance's type args
-	// (e.g. Map<string, Array<int>>).
+	// (e.g. Map<string, Array<int>>). It is absent for a `self` receiver, whose
+	// declared type is the placeholder "self" and carries no type arguments —
+	// there the generic mapping below is skipped and the active substitution
+	// (applied by resolvedTypeName) does the work instead.
 	Type *objType = nullptr;
 	if ( auto *ve = dynamic_cast<VariableExpression*>( (Expression*)mc->mObject ) )
 	{
@@ -1213,14 +1274,12 @@ std::string CodeGen::methodReturnTypeName( MethodCallExpression *mc )
 	}
 	if ( objType == nullptr )
 		objType = ( (Expression*)mc->mObject )->getResolvedType();
-	if ( objType == nullptr )
-		return "";
 
-	// Find the GENERIC (base-name) struct definition and the method.
-	auto sIt = mStructDefMap.find( objType->getName() );
-	if ( sIt == mStructDefMap.end() || sIt->second == nullptr )
+	// Find the GENERIC (base-name) struct definition and the method. Routed
+	// through receiverStructDef so a `self` receiver resolves at all.
+	StructDefinition *sd = receiverStructDef( (Expression*)mc->mObject );
+	if ( sd == nullptr )
 		return "";
-	StructDefinition *sd = sIt->second;
 
 	FunctionDefinition *methodDef = nullptr;
 	for ( auto &m : sd->mMethods )
@@ -1239,7 +1298,7 @@ std::string CodeGen::methodReturnTypeName( MethodCallExpression *mc )
 	// Map the struct's generic params through the object's type arguments:
 	// Map<K,V>.get declared V, object Map<string,int> -> "int".
 	const auto &gps = sd->getGenericParams();
-	for ( size_t i = 0; i < gps.size() &&
+	for ( size_t i = 0; objType != nullptr && i < gps.size() &&
 		  (int)i < objType->getNumTypeParams(); i++ )
 	{
 		if ( gps[i].mName == name )

--- a/CodeGen.h
+++ b/CodeGen.h
@@ -250,6 +250,13 @@ private:
 	// String interpolation codegen
 	llvm::Value *genStringInterpolation( StringInterpolation *interp );
 
+	// Interpolation parts that denote a struct must render through Printable,
+	// not be handed to the string runtime as a BlangString (known-issues KI-8).
+	StructDefinition *structDefForInterpolationPart( Expression *part );
+	llvm::Function *lookupToStringFn( StructDefinition *sd );
+	llvm::Value *genPrintableToString( StructDefinition *sd, Expression *node,
+		llvm::Value *selfPtr );
+
 	// Pipeline expression codegen
 	llvm::Value *genPipelineExpression( PipelineExpression *pipeline );
 

--- a/CodeGen.h
+++ b/CodeGen.h
@@ -250,6 +250,12 @@ private:
 	// String interpolation codegen
 	llvm::Value *genStringInterpolation( StringInterpolation *interp );
 
+	// The struct a receiver/argument expression denotes, resolving the implicit
+	// `self` parameter (whose declared type name is the literal "self"). The
+	// single place that answers "which struct is this?" for a receiver —
+	// see the comment on the definition (known-issues KI-8, KI-10).
+	StructDefinition *receiverStructDef( Expression *obj );
+
 	// Interpolation parts that denote a struct must render through Printable,
 	// not be handed to the string runtime as a BlangString (known-issues KI-8).
 	StructDefinition *structDefForInterpolationPart( Expression *part );

--- a/QExpression.cpp
+++ b/QExpression.cpp
@@ -1,5 +1,6 @@
 #include <assert.h>
 
+#include <cctype>
 #include <iostream>
 #include "FileLexer.h"
 #include "Type.h"
@@ -1105,28 +1106,95 @@ StringInterpolation *StringInterpolation::Parse( Lexer &l, Scope *scope, const s
 			break;
 		}
 
-		// Extract variable name
+		// Extract the placeholder text: a variable name, or a dotted field path
+		// such as `self.count` or `req.path`.
 		string varName = rawString.substr( braceStart + 1, braceEnd - braceStart - 1 );
 
-		// Look up variable in scope
-		SmartPtr<Symbol> sym = scope->findSymbol( varName );
-		if ( sym != nullptr )
+		// Split on '.' so a field path becomes a FieldAccessExpression chain.
+		// Before this, ANY placeholder that was not a bare variable name was
+		// silently copied to the output as literal text — so a program printed
+		// its own source ("{self.x}") with no diagnostic. The rule now is:
+		// resolve it, or reject it; never emit it as text (Principle III).
+		std::vector<string> segs;
 		{
-			VariableDefinition *varDef = dynamic_cast<VariableDefinition*>( (Symbol*)sym );
-			if ( varDef != nullptr )
+			size_t segStart = 0;
+			while ( true )
 			{
-				interp->addPart( new VariableExpression( varDef ) );
+				size_t dot = varName.find( '.', segStart );
+				if ( dot == string::npos )
+				{
+					segs.push_back( varName.substr( segStart ) );
+					break;
+				}
+				segs.push_back( varName.substr( segStart, dot - segStart ) );
+				segStart = dot + 1;
 			}
-			else
+		}
+
+		// A placeholder that is NOT an identifier path is left alone: `{}` and
+		// `{:.2f}` are print FORMAT placeholders handled by FormatString, and a
+		// literal brace run is just text. Only something shaped like a name (or a
+		// dotted name) is resolved — and only that shape is rejected when it does
+		// not resolve. Each segment must obey the identifier rule (leading letter
+		// or underscore), so a positional/format placeholder like `{0}` and an
+		// embedded JSON/template brace stay literal rather than becoming an
+		// error about a variable nobody wrote.
+		bool looksLikePath = !varName.empty();
+		for ( const string &seg : segs )
+		{
+			if ( seg.empty() ||
+				 !( isalpha( (unsigned char)seg[0] ) || seg[0] == '_' ) )
 			{
-				// Not a variable, treat as literal
-				interp->addPart( new ConstString( rawString.substr( braceStart, braceEnd - braceStart + 1 ) ) );
+				looksLikePath = false;
+				break;
 			}
+			for ( char c : seg )
+			{
+				if ( !( isalnum( (unsigned char)c ) || c == '_' ) )
+				{
+					looksLikePath = false;
+					break;
+				}
+			}
+			if ( !looksLikePath )
+				break;
+		}
+		if ( !looksLikePath )
+		{
+			interp->addPart( new ConstString(
+				rawString.substr( braceStart, braceEnd - braceStart + 1 ) ) );
+			pos = braceEnd + 1;
+			continue;
+		}
+
+		// Every segment is a well-formed identifier by the check above, so the
+		// only way this fails is that the BASE names nothing (or names a
+		// non-variable such as a function). Field names are resolved later, by
+		// Sema, which reports its own located "no field" diagnostic.
+		SmartPtr<Symbol> sym = scope->findSymbol( segs[0] );
+		VariableDefinition *varDef = ( sym != nullptr )
+			? dynamic_cast<VariableDefinition*>( (Symbol*)sym ) : nullptr;
+		if ( varDef != nullptr )
+		{
+			Expression *base = new VariableExpression( varDef );
+			base->setLocation( loc );
+			for ( size_t si = 1; si < segs.size(); si++ )
+			{
+				Expression *fa = new FieldAccessExpression( base, segs[si] );
+				fa->setLocation( loc );
+				base = fa;
+			}
+			interp->addPart( base );
 		}
 		else
 		{
-			// Unknown symbol, treat as literal (might be used before declaration)
-			interp->addPart( new ConstString( rawString.substr( braceStart, braceEnd - braceStart + 1 ) ) );
+			// Not resolvable here. Emitting it as literal text is what made this
+			// a silent wrong answer; say so instead. (Sema resolves the FIELD
+			// names above — this only rejects a placeholder whose base is not a
+			// variable in scope at all.)
+			COMPILE_ERROR( l, "cannot interpolate '{" + varName +
+				"}': '" + ( segs.empty() ? varName : segs[0] ) +
+				"' is not a variable in scope" );
 		}
 
 		pos = braceEnd + 1;

--- a/QStatement.cpp
+++ b/QStatement.cpp
@@ -103,6 +103,17 @@ Statement *Statement::Parse( Lexer &l, Scope *scope )
 			if ( statement == nullptr )
 			{
 				l.setCurrentPos( pos );
+				// The expression attempt did not THROW — it simply produced
+				// nothing — so the `deeperError` arm above never ran and
+				// `declErr` was discarded in favour of a generic "Unexpected
+				// token" at the statement's first column. That hid every
+				// located cause raised inside VariableDeclaration::Parse:
+				// `string s = "{missing}";` reported "Unexpected token"
+				// instead of naming the unresolvable interpolation
+				// placeholder. Surface the declaration attempt's located cause,
+				// exactly as the both-threw path already does.
+				if ( declErr.getLocation().isSet() )
+					throw declErr;
 				COMPILE_ERROR( l, "Unexpected token" );
 			}
 		}

--- a/specs/032-stdlib-opaque-api/design-audit.md
+++ b/specs/032-stdlib-opaque-api/design-audit.md
@@ -1,0 +1,131 @@
+# Design audit — U4 stdlib opaque API
+
+**Principle VI artifact**: written and reviewed **before** implementation of the
+accessor surface (epic decision **A4** — the DTO→opaque conversion is public-API
+design, and mechanical field→getter generation is a record-level non-goal).
+
+Status: **awaiting reviewer approval** (`critic`). Implementation of §3 does not
+start until this is approved in the PR.
+
+---
+
+## 1. KI-8 / KI-10 — diagnosis
+
+One fact produced three separate wrong answers: **the implicit `self` parameter's
+declared type name is the literal string `"self"`**; it does not name the enclosing
+struct. Every predicate that resolved a receiver by looking its declared *type name*
+up in `mStructDefMap` therefore missed on a `self` receiver and silently answered
+"not a struct".
+
+**KI-10** was the first symptom: `println("{}", self)` handed a raw struct pointer to
+the string runtime because the print path could not tell `self` was a `Printable`
+struct.
+
+**KI-8(b)** was the same miss one level down, and was **not** a rendering bug — it was
+a use-after-free. `methodReturnTypeName` missed on `self.describe()`, so `isStringType`
+said the expression was not a string, so `genReturnStatement` skipped the retain it
+owes a returned string, and `releaseTempStrings()` then freed the very value being
+returned:
+
+```llvm
+%s = call ptr @P_describe(ptr %self)
+call void @__blang_string_release(ptr %s)   ; refcount 1 -> 0, FREED
+ret ptr %s                                  ; caller gets a dangling pointer
+```
+
+The caller read a freed `BlangString` whose length field had been reused, so the
+program aborted in `concat_many`. `string s = p.delegate();` read `s.length` as 4 for
+a 3-character string before dying on the next read. This is why the earlier naive
+"track it too" patch produced a **double-free**: it added a release without fixing
+the missing retain, treating the symptom at one site instead of the resolution rule.
+
+**Fix at the root**: a single `receiverStructDef(Expression*)` answers "which struct
+is this receiver?" for every caller — resolving `self` through `mSelfStructMap`, a
+field access through `getFieldTypeName` (Sema leaves self-based field types
+unannotated, so this closes the same hole one level down), a generic parameter
+through the active substitution, and gating on `isUserStructType` so builtin names
+cannot slip through. `methodReturnTypeName`, the print-dispatch site and the
+interpolation site all route through it, replacing three ad-hoc lookups.
+
+**Second defect, same root, fourth site**: `genMethodCall` had **no branch for a FIELD
+receiver**. `h.inner.num()` resolved to no struct, so the call was dropped on the
+floor with no diagnostic — printing nothing for a string result and 0 for an int.
+Pre-existing on master. It matters here because composition is exactly the idiom the
+opaque-accessor API pushes code towards.
+
+Evidence: `test_files/codegen_method_return_delegation.b` (committed **red** in
+`8a4d044`, green in `2cf851a`) covers one and two levels of delegation, a bound
+result read twice (a freed string survives one read by luck), `Printable` whose
+`to_string` delegates via all three spellings, a field receiver from inside and
+outside the owning struct, a parameter receiver, and a borrowed-field return for
+contrast (which must keep its retain and must not get a second one).
+`--leak-check`: 159/0, **Leaks: 0** — no leak and no double-free.
+
+## 2. Sweep — where consumers reach into stdlib fields
+
+Scope: `examples/` (6 `.b`), `test_build/` (9), `test_files/` (438), `demos/` (15),
+`stdlib/` (12), root `test.b`. `.length`/`.is_empty` on `string`/`Array` are builtin
+pseudo-fields and are excluded.
+
+**Inventory**: all stdlib structs live in 4 files (`collections.b`, `buffer.b`,
+`fs.b`, `net.b`). `cli/timer/io/math/time/random/env/sys` define **no structs** — zero
+reach-in surface. No `table struct` and no `@json` anywhere in stdlib.
+
+| Type | Reach-ins in `examples/` (**U4 scope**) | Elsewhere (**U5 scope**) |
+|---|---|---|
+| `HttpRequest` | `todo_app:146,147,160,178` (`path`,`method`,`body`) | `demos/13,14`; `test_files/codegen_http*.b` (+8 literal sites) |
+| `Socket` | `chat:93,101,107` (`fd`); `chat:50` **literal** | — |
+| `Map` | `wordfreq:39` (`counts.keys`) | `codegen_map_hashed.b:28` (`m.buckets` — white-box) |
+| `HttpResponse` | none | `codegen_bcc_net_utils.b`, `codegen_http_*.b` (17 reads) |
+| `HttpRequestLine` | none | `codegen_http_blang.b`, `codegen_bcc_net_utils.b` (13 reads) |
+| `HttpParsedHeaders` | none | `codegen_http_blang.b` (7 reads) |
+| `Route`, `HttpServer` | none | `test_files/` literals only |
+| `Buffer`, `File`, `FileInfo`, `ServerSocket`, `Selector` | **none** | **none** — already method-only |
+
+`test_build/` has **zero** reach-ins (its only stdlib importer is `timerapp`, and
+`timer.b` has no structs). So DC8's gate is carried entirely by `examples/`.
+
+**Highest-risk sites, all U5's** (recorded so U5 inherits the analysis):
+1. `codegen_http_routing.b:48-50` fabricates an `HttpServer` from its three
+   underscore-prefixed internals to unit-test routing offline. No public alternative
+   exists; needs an offline constructor + `routes()` accessor, or a rewrite.
+2. `codegen_map_hashed.b:28` reads `m.buckets.length` to assert the open-addressing
+   table grew. No accessor can express this without exposing the representation;
+   either a `bucket_capacity()` test hook or relax the test.
+3. `chat:50` `net.Socket { fd: f }` rebuilds a Socket from a raw int — needs
+   `socket_from_fd`. **This one is U4's**, being in `examples/`.
+
+## 3. Per-type API rationale
+
+**Naming**: accessors take the field's own name (spike S5 proves a method may share a
+field's name and dispatch correctly). Rejected: `get_`-prefixed names and
+`_list`-suffixed names — they invent vocabulary for no benefit and make the U5
+migration a rename instead of adding `()`. The two pre-existing `get_`-named methods
+(`Socket.get_fd`, `FileInfo.get_size`) are left alone: renaming them is churn that
+buys nothing this unit, and `get_fd` is already the spelling `demos/14` uses.
+
+**`HttpParsedHeaders` is the one designed surface, not a getter pair.** Exposing
+`keys()`/`values()` would export the parallel-array *representation* — precisely the
+thing the epic exists to stop, and the representation most likely to change (a hashed
+lookup is the obvious future). The surface is what consumers actually want:
+`has(name)` / `get(name)` for lookup, `count()`/`key(i)`/`value(i)` for ordered
+iteration. Rejected: returning a `Map<string,string>` — it drags a two-argument
+generic into an exported signature, which is exactly what KI-19 says the parser
+rejects before P9 sees it.
+
+**`Map`/`Set` do get plain `keys()`/`values()`/`items()`** — unlike
+`HttpParsedHeaders`, the arrays *are* the concept for a map, and `wordfreq` iterates
+them. They return `Array<K>` / `Array<V>`: **single**-argument generics, so no
+KI-19 exposure.
+
+**Types with zero reach-ins get nothing.** Adding speculative accessors to `Buffer`,
+`File`, `ServerSocket`, `Selector` would be the mechanical generation A4 bans. The
+sweep is the evidence that nothing is missing.
+
+## 4. Open question
+
+**Q-U4-1** (spec §6) — `Map`/`Set` `pub init` (audit AF-1) has **no spelling**: a
+constructor call on a generic type does not parse, and static methods on generic
+structs are not monomorphized. Delivering it needs a parser or codegen change outside
+U4's file set and outside D1–D17. Raised, not improvised. The rest of U4 is
+unaffected.

--- a/specs/032-stdlib-opaque-api/spec.md
+++ b/specs/032-stdlib-opaque-api/spec.md
@@ -1,0 +1,186 @@
+# Spec: stdlib public-API redesign for opaque types
+
+**Epic**: modules-v2-exports · **Unit**: U4 · **Branch**: `epic/modules-v2-exports-u4`
+**Covers**: REQ-010 (+ KI-8 / KI-10, folded in by the 2026-08-05 manager ruling)
+**Depends on**: U2 (merged, `a00bb20`); U3 merged (`54fc372`) · **Speckit**: `032-stdlib-opaque-api`
+**Status**: Draft — §6 carries one BLOCKING open question (Q-U4-1)
+
+Binding inputs: design record D1–D17 (`docs/epics/modules-v2/overview.md`),
+epic decisions A1–A7 (`../../docs/epics/modules-v2-exports/design.md`, esp. **A4**:
+the accessor surface is hand-designed per type and design-audited *before*
+implementation), `known-issues.md` KI-3, KI-8, KI-10, KI-19, and standing checks
+SC-1 / SC-2 (constraint F-1).
+
+---
+
+## 1. Problem
+
+U5 makes member variables always-private and struct literals module-private. Every
+consumer that reads a stdlib struct's field today breaks at that flip. U4 ships the
+**target surface** those consumers migrate onto, and moves `examples/` onto it ahead
+of the flip, so U5 is a rule change rather than a rule change *plus* an API design.
+
+This is API **design** work, not churn (review F8, decision A4). Mechanical
+field→getter generation is a record-level **non-goal**.
+
+Two renderer defects (KI-8, KI-10) were folded into this unit because they break
+exactly the spellings this surface pushes authors towards: once fields are private,
+a method call and `Printable` are the only ways to read data out of an opaque type.
+They are **fixed and merged on this branch already** (§7).
+
+## 2. Goals
+
+- **G1** — every stdlib struct a consumer reaches into gains a `pub` accessor/method
+  surface sufficient to replace the reach-in, hand-designed per type (§4).
+- **G2** — `tools/check_no_field_reachins.sh examples/ test_build/` exits **0**, with
+  a real enumerated maintained field list (DC8).
+- **G3** — all `examples/` compile and their integration scripts pass on the new
+  surface.
+- **G4** — KI-8 and KI-10 fixed with committed regression tests, **before** any U5
+  corpus migration (hard constraint from the workplan).
+- **G5** — docs updated per Principle I (`docs/language_design.md`, `CLAUDE.md`).
+
+## 3. Non-goals
+
+- **The U5 corpus migration.** `test_files/` and `demos/` reach-ins are U5's. DC8
+  scopes the gate to `examples/` and `test_build/` deliberately. This unit does not
+  migrate `test_files/codegen_http*.b`, `demos/13_http_server.b`,
+  `demos/14_file_server.b`, or `test_files/codegen_map_hashed.b`.
+- **Making fields actually private.** Field access keeps working this epic-unit; U4
+  ships the target surface only. Enforcement is U5.
+- **`buffer` / `collections` / `cli` module-private enforcement** — exempt this epic
+  (A7, KI-3). Accessors are still *added* to `Map`/`Set` (they are needed by
+  `examples/wordfreq`), but no visibility rule is applied to them here.
+- **The flat-merge resolution path** (`qcc.cpp`), any **generic factory**, and
+  anything under `runtime/` — untouched, per the epic scope guards.
+- **KI-15, KI-18** — U5's.
+
+## 4. Design — the accessor surface
+
+Derived from an exhaustive sweep of `examples/`, `test_build/`, `test_files/`,
+`demos/`, `stdlib/` (recorded in `design-audit.md` §2). Types with **zero** consumer
+reach-ins (`Buffer`, `File`, `ServerSocket`, `Selector`) get no new surface — their
+existing method surface already suffices; the sweep is the evidence.
+
+**Naming rule (enabled by spike S5, §5): an accessor takes the field's own name.**
+A method may share a name with a field and dispatch is correct, so migration is
+purely *adding `()`* — the smallest possible diff, and no invented vocabulary
+(`get_`/`_list` suffixes) leaks into the public API. `self.method` inside the
+accessor still reads the field.
+
+| Type | New `pub` surface | Replaces |
+|---|---|---|
+| `net.HttpRequest` | `method()`, `path()`, `body()` | `req.method` / `.path` / `.body` |
+| `net.HttpResponse` | `status()`, `content_type()`, `body()` | `resp.status` / `.body` / `.content_type` |
+| `net.HttpRequestLine` | `method()`, `path()`, `version()` — **new impl block** | `reqline.method` etc. |
+| `net.HttpParsedHeaders` | `count()`, `key(i)`, `value(i)`, `has(name)`, `get(name)` — **new impl block** | `hdrs.keys[i]` / `hdrs.values[i]` |
+| `fs.FileInfo` | mark existing `exists`/`is_file`/`is_dir`/`get_size` **`pub`** | (already method-only) |
+| `net.Socket` | mark existing `get_fd()` **`pub`** | `conn.fd` |
+| `collections.Map` | `keys()`, `values()` | `counts.keys` |
+| `collections.Set` | `items()` | (none in `examples/`; symmetry) |
+
+`HttpParsedHeaders` is the one type that gets a **designed** surface rather than
+getters: the parallel-array representation is precisely what should not be public.
+`has`/`get` are the operations consumers actually want; `count`/`key`/`value` retain
+ordered iteration without exposing the arrays.
+
+### 4.1 Construction
+
+`HttpResponse` needs no builder — every consumer already goes through
+`http_ok`/`http_json`/`http_not_found`/`http_response`. `HttpRequest`, `Route`,
+`Socket` are literal-constructed by consumers today; free constructors
+(`net.http_request(...)`, `net.route(...)`, `net.socket_from_fd(int)`) are the U5
+migration target. **Only `socket_from_fd` is required by U4**, because
+`examples/chat/main.b:50` is the sole `examples/` literal site; the others serve
+`test_files/`, which is U5's. They are specified here so U5 inherits a design, not a
+decision.
+
+### 4.2 P9 / KI-19 accounting
+
+`Map`/`Set` accessors return `Array<K>` / `Array<V>` — **single**-argument generic
+types. The multi-argument form (`Map<string,Secret>`) that KI-19 flags is **not**
+introduced into any exported signature by this unit, so U4 does not rely on P9
+having checked a construct the parser rejects first. This is stated explicitly
+because "no P9 error on a `Map` signature" must not be read as "P9 checked it".
+
+## 5. Spike findings (run before design, per Principle VI / A4)
+
+| # | Question | Result |
+|---|---|---|
+| S5 | May a method share a name with a field? | **Yes** — compiles, and runs correctly (`r.method()` → method, `self.method` → field; printed `GET /x`). This is what makes §4's naming rule viable. |
+| S1 | Does `Box<int>()` (ctor call on a generic) parse? | **No** — `error: Failed parse value`. `QExpression.cpp:369-416` accepts `Name<Args>` only before `{`, never before `(`. |
+| S3 | Does a zero-arg `static fn new()` on a generic work? | Parses; **fails codegen**: `undefined function 'new' (mangled: Box_new)`. |
+| S4 | Does an *inferable* `static fn make(T)` on a generic work? | Parses; **fails codegen** the same way. Static methods on generic structs are not monomorphized. |
+
+S1/S3/S4 together are the basis of Q-U4-1.
+
+## 6. Open questions
+
+### Q-U4-1 (BLOCKING for one clause) — `Map`/`Set` `pub init` has no spelling
+
+The workplan (audit **AF-1**) requires U4 to *"add `pub init` to `Map` and `Set` —
+their only construction form today is the struct literal U5 outlaws — and migrate
+the literal call sites with their goldens"* (14 real sites).
+
+**There is no way to construct a generic struct other than a struct literal.** All
+three candidate spellings fail (§5): the constructor call does not parse, and static
+factory methods on generic structs are not monomorphized by codegen.
+
+Delivering this clause therefore requires **either**:
+
+- **(a)** a parser change — accept `Name<Args>(...)` and build a `ConstructExpression`
+  carrying the type args, plus codegen to monomorphize and call the instantiated
+  `init`; or
+- **(b)** a codegen change — monomorphize `static fn` on generic structs, then
+  `Map.new()` / `Map.make(...)`; still needs LHS-type inference for the zero-arg case.
+
+Both are **language/compiler surface changes**, outside U4's stated file set
+(`stdlib/*.b`, `examples/`), and neither is covered by D1–D17.
+
+**Why it does not block the rest of U4**: struct literals are not field reach-ins, so
+DC8's gate does not flag them; `collections` is exempt from module-private
+enforcement this epic (A7/KI-3), so `Map`/`Set` literals keep working; and the one
+`examples/` `Map` reach-in (`wordfreq:39 counts.keys`) needs an **accessor**, not
+`init`. G1–G5 are all deliverable without an answer.
+
+**Recommendation**: defer the clause to U5 (which owns the literal flip and would
+otherwise have to design the construction spelling twice), or split it into its own
+unit. Raised rather than improvised, per the epic execution rules.
+
+## 7. KI-8 / KI-10 — already landed on this branch
+
+| Commit | Content |
+|---|---|
+| `5e3cfdc` | Interpolation renders dotted paths, structs and `self` — or rejects them (KI-8(a), KI-10). Golden `codegen_print_printable.expected.out` had **frozen the KI-10 bug** (it expected the literal text `({self.x}, {self.y})`); it now expects `(10, 20)`. |
+| `8a4d044` | KI-8(b) regression test, committed **deliberately red**. |
+| `2cf851a` | KI-8(b) fix — one `receiverStructDef()` resolves a receiver's struct for every caller. Also fixed a second defect at the same root: `genMethodCall` had no FIELD-receiver branch, so `h.inner.num()` was silently dropped. |
+
+Diagnosis and evidence: `design-audit.md` §1.
+
+## 8. Test plan
+
+- **DC8 gate**: `tools/check_no_field_reachins.sh examples/ test_build/` exits 0.
+  The script's field list stays a **real enumeration** — a wildcard that trivially
+  passes is explicitly rejected. `FileInfo:name` (a field that does not exist) is
+  removed; `Map`/`Set` fields are added.
+- **Negative leg**: the gate must be shown to have teeth — a deliberately
+  reintroduced reach-in makes it exit non-zero.
+- **`examples/`**: every integration script passes. `todo_app`'s libm link failure is
+  **environmental** (dangling `libsqlite3.so` symlink) and settled — it must not be
+  read as a regression.
+- **Gates**: `run_tests.sh` + `test_codegen.sh` green in **both** build modes;
+  `test_codegen.sh --leak-check` clean; `test_lsp.sh`; `test_build/run_build_tests.sh`;
+  `ctest`.
+- **SC-1 / F-1**: this unit adds **no new `.bmod` construct** (it adds `pub` methods to
+  stdlib source, which the existing emitter already handles), so F-1's fixture
+  obligation is not triggered. SC-1 continues to run via `test_build/`.
+
+## 9. Traceability
+
+| Goal | Requirement | Verified by |
+|---|---|---|
+| G1 | REQ-010 | §4 surface implemented; sweep in `design-audit.md` §2 is the completeness argument |
+| G2 | REQ-010 / DC8 | gate exits 0 + negative leg |
+| G3 | REQ-010 / DC8 | `examples/*/test_*.sh` |
+| G4 | KI-8, KI-10 | `codegen_method_return_delegation.b`, `codegen_print_printable.b` |
+| G5 | Principle I | `docs/language_design.md`, `CLAUDE.md` |

--- a/test_files/codegen_interp_expressions.b
+++ b/test_files/codegen_interp_expressions.b
@@ -1,0 +1,110 @@
+// Regression: which expressions a string interpolation can actually render.
+//
+// Three wrong answers used to live here, all silent (known-issues KI-8, KI-10):
+//
+//   1. a DOTTED placeholder ("{p.x}") was copied to the output as literal
+//      SOURCE TEXT, so a program printed "{p.x}" instead of the field value;
+//   2. a bare STRUCT placeholder ("{s}") was handed straight to
+//      __blang_string_concat_many as if the struct pointer were a BlangString —
+//      a type confusion at the C boundary that rendered as empty;
+//   3. `self` as a print argument fell through the same hole, because the
+//      implicit self parameter's declared type name is the literal "self" and
+//      so failed every "is this a struct?" test.
+//
+// The rule this locks in: an interpolation placeholder is RESOLVED (through
+// Printable for a struct, exactly as the `{}` format placeholder does) or
+// REJECTED — it is never emitted as source text and never silently dropped.
+struct Inner {
+	int depth;
+	string label;
+}
+
+impl Inner {
+	init(int d, string l) {
+		self.depth = d;
+		self.label = l;
+	}
+}
+
+struct Outer {
+	int id;
+	string name;
+	Inner inner;
+}
+
+impl Outer {
+	init(int i, string n, Inner nested) {
+		self.id = i;
+		self.name = n;
+		self.inner = nested;
+	}
+
+	// A dotted path rooted at `self`, both an int and a refcounted string field.
+	fn describe(self) -> string {
+		return "Outer(id={self.id},name={self.name})";
+	}
+
+	// `self` as a whole, as a print argument: must dispatch through Printable.
+	fn show_self(self) {
+		println("self-arg = {}", self);
+	}
+}
+
+impl Printable for Outer {
+	fn to_string(self) -> string {
+		return "Outer#{self.id}";
+	}
+}
+
+struct Plain {
+	int v;
+}
+
+impl Plain {
+	init(int a) { self.v = a; }
+}
+
+impl Printable for Plain {
+	fn to_string(self) -> string {
+		return "Plain({self.v})";
+	}
+}
+
+fn main() -> int {
+	Inner i = Inner(2, "deep");
+	Outer o = Outer(7, "seven", i);
+
+	// 1. Dotted path on a local: int field and string field.
+	println("{}", "id={o.id}");
+	println("{}", "name={o.name}");
+
+	// 2. Nested dotted path — two levels of field access.
+	println("{}", "depth={o.inner.depth}");
+	println("{}", "label={o.inner.label}");
+
+	// 3. Dotted path rooted at `self` inside a method body.
+	println("{}", o.describe());
+
+	// 4. `self` as a whole print argument, dispatched through Printable.
+	o.show_self();
+
+	// 5. A bare STRUCT placeholder inside an interpolated literal must render
+	//    the same text as the `{}` format placeholder does.
+	Plain p = Plain(41);
+	println("{}", "interp=[{p}]");
+	println("placeholder=[{}]", p);
+	// The whole literal is ONE placeholder: the interpolation returns the
+	// to_string result directly rather than concatenating, a distinct ownership
+	// path from the multi-part case above.
+	println("{}", "{p}");
+
+	// 6. Several placeholders and literal text in one string.
+	println("{}", "{o.id}/{o.name}/{o.inner.depth}");
+
+	// 7. A format placeholder is NOT an identifier path and must be left alone
+	//    for the format-string layer.
+	println("fmt={} and {:x}", 12, 255);
+
+	println("interp expressions codegen test passed!");
+	return 0;
+}

--- a/test_files/codegen_interp_expressions.expected.out
+++ b/test_files/codegen_interp_expressions.expected.out
@@ -1,0 +1,12 @@
+id=7
+name=seven
+depth=2
+label=deep
+Outer(id=7,name=seven)
+self-arg = Outer#7
+interp=[Plain(41)]
+placeholder=[Plain(41)]
+Plain(41)
+7/seven/2
+fmt=12 and ff
+interp expressions codegen test passed!

--- a/test_files/codegen_method_return_delegation.b
+++ b/test_files/codegen_method_return_delegation.b
@@ -108,6 +108,14 @@ fn main() -> int {
 	println("I={}", h.describe());
 	println("J={}", via_param(p));
 
+	// A method call whose RECEIVER is a field, from outside the owning struct.
+	// genMethodCall had no branch for a field receiver at all, so this call was
+	// dropped on the floor with no diagnostic: it printed nothing (and `int`
+	// results printed 0). Composition — an object delegating to a field — is
+	// the shape an accessor-only API pushes code towards, so it must work.
+	println("M={}", h.inner.describe());
+	println("N={}", h.inner.get_tag());
+
 	// A borrowed field return still hands the caller its own reference.
 	string t = p.get_tag();
 	println("K={}", t);

--- a/test_files/codegen_method_return_delegation.b
+++ b/test_files/codegen_method_return_delegation.b
@@ -1,0 +1,118 @@
+// Regression: a method that RETURNS another method's string result freed the
+// string before returning it (known-issues KI-8(b)).
+//
+//   fn to_string(self) -> string { return self.describe(); }
+//
+// compiled to:
+//
+//   %s = call ptr @P_describe(ptr %self)
+//   call void @__blang_string_release(ptr %s)   <- refcount 1 -> 0, FREED
+//   ret ptr %s                                   <- caller gets a dangling ptr
+//
+// Root cause, and it is the same one as KI-10: the implicit `self` parameter's
+// declared type name is the literal string "self", not the enclosing struct's
+// name. `methodReturnTypeName` resolves a receiver by looking its declared type
+// name up in the struct map, so it missed on every self receiver and returned
+// "". `isStringType` therefore said "not a string" for `self.describe()`, the
+// return statement skipped its retain, and the scope's temp-string release
+// freed the value being returned.
+//
+// It reproduced as heap corruption, not as a clean crash: the caller printed a
+// freed BlangString whose length field had been reused, so the runtime aborted
+// with "out of memory in string concat_many". A test that only checks the exit
+// code of a program that never reads the string would miss it entirely — hence
+// the reads below.
+struct P {
+	int n;
+	string tag;
+}
+
+impl P {
+	init(int a, string t) {
+		self.n = a;
+		self.tag = t;
+	}
+
+	fn describe(self) -> string {
+		return "P({self.n},{self.tag})";
+	}
+
+	// One level of delegation: return another method's string result.
+	fn delegate(self) -> string {
+		return self.describe();
+	}
+
+	// Two levels: the delegation is itself delegated.
+	fn delegate2(self) -> string {
+		return self.delegate();
+	}
+
+	// A borrowed field, for contrast — this path always worked and must stay
+	// working (it needs the retain that a fresh temp must NOT get twice).
+	fn get_tag(self) -> string {
+		return self.tag;
+	}
+}
+
+impl Printable for P {
+	// The shape from the KI-8(b) report: Printable's to_string delegates.
+	fn to_string(self) -> string {
+		return self.describe();
+	}
+}
+
+struct Holder {
+	P inner;
+}
+
+impl Holder {
+	init(P p) {
+		self.inner = p;
+	}
+
+	// Delegation through a FIELD receiver rather than `self`.
+	fn describe(self) -> string {
+		return self.inner.describe();
+	}
+}
+
+// Delegation through a plain parameter receiver, outside any method.
+fn via_param(P p) -> string {
+	return p.describe();
+}
+
+fn main() -> int {
+	P p = P(3, "hi");
+
+	// Direct call — always worked.
+	println("A={}", p.describe());
+
+	// One and two levels of delegation. Each returned string is then READ
+	// (concatenated into the print), which is what turns a use-after-free into
+	// an observable wrong answer rather than a silently ignored one.
+	println("B={}", p.delegate());
+	println("C={}", p.delegate2());
+
+	// Bind first, then read twice: a freed string survives one read by luck.
+	string s = p.delegate();
+	println("D={}", s);
+	println("E={}", s);
+
+	// Printable dispatch whose to_string delegates — both spellings must agree.
+	println("F={}", p.to_string());
+	println("G={}", p);
+	println("H={}", "[{p}]");
+
+	// Field receiver and parameter receiver.
+	Holder h = Holder(p);
+	println("I={}", h.describe());
+	println("J={}", via_param(p));
+
+	// A borrowed field return still hands the caller its own reference.
+	string t = p.get_tag();
+	println("K={}", t);
+	println("L={}", p.get_tag());
+
+	println("method return delegation codegen test passed!");
+	return 0;
+}

--- a/test_files/codegen_method_return_delegation.expected.out
+++ b/test_files/codegen_method_return_delegation.expected.out
@@ -1,0 +1,15 @@
+A=P(3,hi)
+B=P(3,hi)
+C=P(3,hi)
+D=P(3,hi)
+E=P(3,hi)
+F=P(3,hi)
+G=P(3,hi)
+H=[P(3,hi)]
+I=P(3,hi)
+J=P(3,hi)
+M=P(3,hi)
+N=hi
+K=hi
+L=hi
+method return delegation codegen test passed!

--- a/test_files/codegen_print_printable.expected.out
+++ b/test_files/codegen_print_printable.expected.out
@@ -1,2 +1,2 @@
-point: ({self.x}, {self.y})
+point: (10, 20)
 print printable codegen test passed!

--- a/test_files/fail/sema/interp_unknown_base.b
+++ b/test_files/fail/sema/interp_unknown_base.b
@@ -1,0 +1,11 @@
+// A string-interpolation placeholder whose base names nothing in scope must be
+// REJECTED with a located diagnostic.
+//
+// It used to be copied into the output as literal source text, so this program
+// compiled clean and printed "value={missing}" at runtime — a silent wrong
+// answer with no diagnostic anywhere (known-issues KI-8).
+fn main() -> int {
+	string s = "value={missing}";
+	println("{}", s);
+	return 0;
+}

--- a/test_files/fail/sema/interp_unknown_base.b.expected
+++ b/test_files/fail/sema/interp_unknown_base.b.expected
@@ -1,0 +1,6 @@
+# U4 fail/sema fixture: a string-interpolation placeholder whose base is not a
+# variable in scope. Before U4 this was emitted as literal SOURCE TEXT, so the
+# program printed "value={missing}" with no diagnostic at all (known-issues
+# KI-8(a)). Pattern combines the canonical located-error format with the
+# specific message. Same in both build modes.
+^[^:]+\.b:[0-9]+:[0-9]+: error: cannot interpolate '\{missing\}': 'missing' is not a variable in scope$


### PR DESCRIPTION
Epic **modules-v2-exports**, unit **U4** (REQ-010 + KI-8/KI-10). Opened early and as a **draft** so the diff is reviewable while the accessor surface is still pending a blocking answer (see below).

## What is landed here

| Commit | Content |
|---|---|
| `5e3cfdc` | KI-8(a) + KI-10 — interpolation renders dotted paths, structs and `self`, or rejects them with a located error |
| `8a4d044` | KI-8(b) regression test, committed **deliberately red** |
| `2cf851a` | KI-8(b) fix — one `receiverStructDef()` for every receiver-resolution site; plus a second defect at the same root |
| `d706b1d` | Principle VI design audit + spec for the accessor surface (no stdlib source changes) |

### KI-8(b) diagnosis

Not a rendering bug — a **use-after-free**. The implicit `self` parameter's declared type name is the literal string `"self"`, so every predicate resolving a receiver by type-name lookup silently missed on a `self` receiver. `methodReturnTypeName` missed on `self.describe()` → `isStringType` said "not a string" → `genReturnStatement` skipped the retain a returned string is owed → `releaseTempStrings()` freed the value being returned:

```llvm
%s = call ptr @P_describe(ptr %self)
call void @__blang_string_release(ptr %s)   ; 1 -> 0, FREED
ret ptr %s                                  ; caller gets a dangling pointer
```

That is why the earlier naive "track it too" patch produced a **double-free**: it added a release without supplying the missing retain. The fix is at the root — a single `receiverStructDef()` resolving `self` via `mSelfStructMap`, field receivers via `getFieldTypeName`, generics via the active substitution. A **second pre-existing defect** surfaced at the same root: `genMethodCall` had no FIELD-receiver branch, so `h.inner.num()` was silently dropped with no diagnostic — which matters because composition is the idiom an opaque-accessor API pushes code towards.

The golden `codegen_print_printable.expected.out` had **frozen the KI-10 bug** — it expected the literal text `({self.x}, {self.y})` and now expects `(10, 20)`.

## Blocking open question — Q-U4-1

Audit **AF-1** asks U4 to give `Map`/`Set` a `pub init` and migrate the 14 struct-literal call sites. **There is no spelling for constructing a generic struct other than a struct literal:**

| Spike | Result |
|---|---|
| `Box<int>()` | **parse error** — `QExpression.cpp:369-416` accepts `Name<Args>` only before `{`, never before `(` |
| `static fn new()` (zero-arg) | parses; **codegen** `undefined function 'new' (mangled: Box_new)` |
| `static fn make(T)` (inferable) | parses; same codegen failure — static methods on generic structs are not monomorphized |

Delivering the clause needs a parser change or a codegen change, both outside U4's file set (`stdlib/*.b`, `examples/`) and outside D1–D17. **Raised, not improvised.** It does not block the rest of U4 — literals are not field reach-ins so the DC8 gate does not flag them, `collections` is exempt this epic (A7/KI-3), and the one `examples/` `Map` reach-in needs an accessor.

## KI-19 accounting

The designed surface introduces **no multi-argument generic** into any exported signature: `Map`/`Set` accessors return `Array<K>`/`Array<V>` (single-argument). Returning a `Map<string,string>` from `HttpParsedHeaders.get` was considered and **rejected** for exactly this reason. So U4 does not read "no P9 error on a `Map` signature" as "P9 checked it".

## Gates (baseline on this branch, both build modes)

| Gate | Result |
|---|---|
| `run_tests.sh` (LLVM) | **234 / 0** |
| `run_tests.sh` (parse-only, `build-nollvm`) | **227 / 0** |
| `test_codegen.sh` | **159 / 0** (152 golden-checked, 7 quarantined) |
| `test_codegen.sh --leak-check` | **159 / 0, Leaks: 0** |
| `test_lsp.sh` | **63 / 0** |
| `test_build/run_build_tests.sh` | green (incl. SC-1 `qcc --parse-only` on every emitted `.bmod`) |
| `tools/check_no_field_reachins.sh examples/ test_build/` | exit **1** — expected pre-migration; DC8 turns this to 0 |

## Still to come (after Q-U4-1 is answered)

Accessor surface implementation (§4 of the spec), `examples/` migration, DC8 gate to 0 with a real enumerated field list + a negative teeth leg, docs per Principle I.

## Scope guards honored

Flat-merge path in `qcc.cpp` untouched · no generic factory · generics keep full layout + all method bodies · `buffer`/`collections`/`cli` exempt · nothing under `runtime/` · KI-15/KI-18 remain U5's · no U5 corpus migration started.