### PR TITLE
modules-v2-graph: epic closeout — core complete (DC1-9,DC12) + DC10; defer DC11 (KG-10)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -682,23 +682,28 @@ The long-term goals (from README.txt) include integrated threading, eventing, ga
     `modules-v2-graph` Epic B — module identity, per-module scopes, import
     enforcement, type tiers, module-prefix ARC fix, cross-module LSP — to be
     planned after Epic A completes).
-  - `modules-v2-graph` (`docs/epics/modules-v2-graph/`) — status: **launched**
-    (run `3e3dbafe-0cd0-4838-bb98-10d3a17fedc5`, 2026-08-09; full scope U1–U9).
-    Epic B of the modules-v2 split (the resolution half): canonical module
-    identity (fixes P10 generic-mangling collapse), three type tiers
-    core/prelude/library (prelude = `{Map,Set,Buffer}`, delete bare-name
-    registration, demote `cli`), the module-prefix string-ARC codegen fix (crux,
-    unblocks retiring the `buffer`/`collections`/`cli` promotions — closes KI-3),
-    a per-module import graph via an **extractable resolver** (removes the
-    flat-merge injection), enforced imports with use/name-capability (D7) +
-    located collision/unknown/unused diagnostics, foreign-type refs in `.bmod` +
-    the transitive build graph (closes KI-5), and two stretch units (import
-    aliasing, module search path). Owner decisions (2026-08-09): cross-module LSP
-    split to a follow-on **Epic C (`modules-v2-lsp`)** that consumes U4's resolver
-    seam; both stretch units in scope; fully-autonomous/generous. Inherits
-    KI-3/KI-5/KI-16/KI-23 from Epic A. 9 units (U1–U9), REQ-001..014. Binding
-    design record: `docs/epics/modules-v2/overview.md` (D1–D17). Next:
-    `/devbot-review modules-v2-graph`.
+  - `modules-v2-graph` (`docs/epics/modules-v2-graph/`) — status: **core complete**
+    (all core done-conditions DC1–9 + DC12 closed, plus stretch DC10; DC11 deferred).
+    Epic B of the modules-v2 split (the resolution half). **Closed:** canonical
+    module identity — DC1 (U1, fixes P10 generic-mangling collapse); three type
+    tiers core/prelude/library — DC2/DC3 (U3, prelude = `{Map,Set,Buffer}`,
+    bare-name registration deleted, `cli` demoted in U6); the module-prefix
+    string-ARC codegen fix — DC4 (U2, closes KI-3); the **extractable Resolver**
+    seam — DC5 (U4); a per-module import graph with enforced imports + D7
+    use/name-capability + injection removal — DC6 (U6a/U6b-1); foreign-type refs in
+    `.bmod` + the transitive build graph + un-named foreign generic — DC7 (U5,
+    closes KI-5); located collision/unknown/unused-import diagnostics + D3
+    "did you mean" sharpening — DC8 (U6b-2); combine-mode field privacy keyed on
+    module identity — DC9 (U6b-3, closes KI-23); **stretch** import aliasing
+    `import x as y;` — DC10 (U8). **Deferred:** DC11 (U9, module search path /
+    configurable resolution roots) → follow-on epic, recorded KG-10 (a build-driver
+    change, a clean boundary; deferring a stretch unit does not fail the core).
+    Inherited KI-3/KI-5/KI-16/KI-23 from Epic A all closed. Known-gaps filed: KG-6
+    (closed), KG-8 (bcc diamond false-positive), KG-9 (DC9 basename identity),
+    KG-10 (DC11 deferral). Cross-module LSP is the separate follow-on **Epic C
+    (`modules-v2-lsp`)** consuming U4's resolver seam. Binding design record:
+    `docs/epics/modules-v2/overview.md` (D1–D17); specs `034`–`040`. Merged PRs
+    this line: #147–#155.
   - `001-toolchain-and-stdlib` (`docs/epics/001-toolchain-and-stdlib/`) — status:
     **complete-local** (devbot run `3a358cfb-38ff-4189-82f5-172d64f05c14`; all 7
     units U0–U6 merged to local master; done-conditions #1–#5 independently

--- a/docs/epics/modules-v2-graph/known-issues.md
+++ b/docs/epics/modules-v2-graph/known-issues.md
@@ -11,6 +11,35 @@ by their listed units.)
 
 ---
 
+## KG-10 — DC11 (module search path / std separation) deferred to a follow-on epic
+
+**Filed**: epic closeout (after U8). **Owner**: follow-on epic. **Not a defect — a scoped deferral** (workplan-sanctioned: a stretch unit may defer without failing the core done-condition).
+
+Done-condition 11 (U9) asks to replace the hardcoded `stdlib/<name>.b` mapping with
+**configurable resolution roots**, so a user module named `timer` deterministically
+**shadows** the stdlib `timer` (P7), proven by a `test_build` fixture built with a
+custom resolution root. This is the epic's **second** stretch unit; the first
+(DC10, import aliasing) landed in U8.
+
+**Why deferred.** It is a **build-driver** change — `bcc`/`ProjectConfig` gain a
+resolution-roots concept and a deterministic search order (user roots before the
+bundled stdlib), and `bcc`'s stdlib assembly (`resolveStdlibFiles` / the
+`kKnownOrder` mapping) is rewritten to consult it. That is materially different in
+character and risk from the **resolution-model** work this epic delivered (module
+identity, capability, import graph, diagnostics, field privacy) — a clean boundary
+for a separate unit. The epic's **core** (DC1–9, DC12) plus the first stretch unit
+(DC10) are complete and green; deferring DC11 does not fail the core done-condition
+(the workplan states stretch units defer to a follow-on recorded here).
+
+**Follow-on scope.** A small epic: (a) a `[resolution]` / roots concept in
+`blang.toml` + `ProjectConfig`; (b) a deterministic search order (user roots →
+bundled stdlib); (c) `bcc` stdlib assembly consulting it; (d) a `test_build`
+fixture where a user `timer.b` under a custom root shadows the stdlib `timer` and
+the program links against the user version. Single-file/combine mode keeps the
+current bundled-stdlib behavior when no roots are configured (backward compatible).
+
+---
+
 ## KG-9 — DC9 field-privacy keys on the file BASENAME, so two same-named modules in different dirs collapse
 
 **Filed**: U6b-3. **Owner**: follow-on (module-identity precision); flagged by the U6b-3 reviewer.


### PR DESCRIPTION
## modules-v2-graph — epic closeout (docs-only)

Reviewer: **@reviewer** (secondary reviewer; distinct from @auditor).

Records the final epic state after U8 merged. **Docs-only** — no source change.

### Final done-condition status
| DC | Status | Unit |
|---|---|---|
| DC1 canonical module identity | ✅ | U1 |
| DC2 three type tiers | ✅ | U3 |
| DC3 prelude manifest / bare-name delete / cli demotion | ✅ | U3/U6 |
| DC4 module-prefix string-ARC codegen fix | ✅ | U2 |
| DC5 extractable Resolver seam | ✅ | U4 |
| DC6 imports enforced; use/name capability; injection removed | ✅ | U6a/U6b-1 |
| DC7 foreign-type refs + transitive graph + un-named generic | ✅ | U5 |
| DC8 collision & import diagnostics + D3 sharpening | ✅ | U6b-2 |
| DC9 combine-mode field privacy (KI-23) | ✅ | U6b-3 |
| DC12 no regressions; docs updated | ✅ | all |
| **DC10 import aliasing (stretch)** | ✅ | U8 |
| **DC11 module search path (stretch)** | ⏳ **deferred → follow-on (KG-10)** |

### Deferral (KG-10)
DC11 (configurable resolution roots so a user `timer` shadows stdlib `timer`) is a **build-driver** change (`bcc`/`ProjectConfig` roots + user-before-stdlib search order) — materially different in character/risk from this epic's resolution-model work, a clean boundary for a follow-on. Per the workplan, deferring a stretch unit does **not** fail the core done-condition.

### Records
- **CLAUDE.md** active-epic status → "core complete", with the per-DC closure map and merged PR range (#147–#155).
- **known-issues.md**: KG-10 (DC11 deferral) added; KG-6 closed; KG-8 (bcc diamond false-positive), KG-9 (DC9 basename identity) on file. Inherited KI-3/KI-5/KI-16/KI-23 all closed.

### State
Master CI green after all six merges this session (U6a, U6b-1/2/3, U8). Latest full-suite result on master: `run_tests` 244/0 (LLVM) + 237/0 (parse-only), `test_codegen` 168/0, `--leak-check` Leaks:0, `test_lsp` 63/0, `test_build` all pass.